### PR TITLE
Using full equal sign to check `undefined` or `null`

### DIFF
--- a/src/lib/tool.js
+++ b/src/lib/tool.js
@@ -58,10 +58,10 @@ export function isBoolean(value) {
   return Object.prototype.toString.call(value) == '[object Boolean]';
 }
 export function isUndefined(value) {
-  return Object.prototype.toString.call(value) == '[object Undefined]';
+  return value === undefined;
 }
 export function isNull(value) {
-  return Object.prototype.toString.call(value) == '[object Null]';
+  return value === null;
 }
 export function isSymbol(value) {
   return Object.prototype.toString.call(value) == '[object Symbol]';


### PR DESCRIPTION
vconsole的维护者应该都是腾讯的同事，所以就直接写中文了（逃

今天使用时发现，部分 ES6 polyfill 会改写 `Object.prototype.toString`（例如这个 [Symbol 的 polyfill](https://github.com/Financial-Times/polyfill-service/blob/master/packages/polyfill-library/polyfills/Symbol/polyfill.js#L215-L219)），而 vconsole 对于 `undefined` 和 `null` 的类型判断直接调用了这个方法，导致 `.call(undefined)` ，然后返回 `[object Window]`，也就是说此时：

```js
tool.isObject(undefined) === true
```

最终导致这里的代码报错：
https://github.com/Tencent/vConsole/blob/aa30ca1331aa4d68e8c7935eb9e10b2d20218f90/src/log/log.js#L408-L410

```
Uncaught TypeError: Failed to execute 'insertAdjacentElement' on 'Element': parameter 2 is not of type 'Element'.
    at VConsoleDefaultTab.printLog (log.js?5e1e:356)
    at VConsoleDefaultTab.onReady (log.js?5e1e:130)
    at VConsoleDefaultTab.onReady (default.js?5d0a:23)
    at VConsoleDefaultTab.trigger (plugin.js?986b:61)
    at VConsole._initPlugin (core.js?cf12:409)
    at VConsole._autoRun (core.js?cf12:316)
    at _onload (core.js?cf12:47)
```


这个问题无法在 polyfill 侧修复，因为 polyfill 必须保证：

```js
Object.prototype.toString.call(Symbol(123)) === '[object Symbol]'
```

正确做法应该是，vconsole 对于 `undefined` 和 `null` 的判断直接用全等号就行了，`null` 和 `undefined` 都是原始类型。