### PR TITLE
修复部分情况下数组索引顺序显示错误的问题

### DIFF
--- a/src/lib/tool.js
+++ b/src/lib/tool.js
@@ -185,6 +185,13 @@ export function getObjAllKeys(obj) {
     }
   }
   keys = keys.sort();*/
+  if (isArray(obj)) {
+    const m = [];
+    obj.forEach((_, index) => {
+      m.push(index)
+    });
+    return m.concat('length');
+  }
   return  Object.getOwnPropertyNames(obj).sort();
 }
 


### PR DESCRIPTION
`getObjAllKeys` 方法中的传参 `obj` 有可能是数组，直接应用 `Object.getOwnPropertyNames(obj)` 或者之前的 `for (let key in obj)` 得到的 key 顺序是按字符串顺序排列的，而不是数组索引顺序。

另外，考虑到 `obj` 有可能是稀疏数组，因此通过 `forEach` 获取数组索引，而不是 `for in` 或者 `map`。

**before:**
![image](https://user-images.githubusercontent.com/5269004/45113658-85494500-b17d-11e8-87fa-1c19eeadbb83.png)


**after:**
![image](https://user-images.githubusercontent.com/5269004/45113687-9d20c900-b17d-11e8-8e4d-565ed9f41488.png)
