### PR TITLE
fix: issue 204 VConsoleDefaultTab.mockConsole功能不符合预期。

### DIFF
--- a/src/log/default.js
+++ b/src/log/default.js
@@ -24,7 +24,6 @@ class VConsoleDefaultTab extends VConsoleLogTab {
   constructor(...args) {
     super(...args);
     this.tplTabbox = tplTabbox;
-    this.windowOnError = null;
   }
 
   onReady() {


### PR DESCRIPTION
此修改是为了使引入vConsole之前自定义的window.onerror能被正常执行