### PR TITLE
reverse isInited when destroyed

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -731,6 +731,9 @@ class VConsole {
     }
     // remove DOM
     this.$dom.parentNode.removeChild(this.$dom);
+
+    // reverse isInited when destroyed
+    this.isInited = false;
   }
 
 } // END class


### PR DESCRIPTION
`destroy()` runs into error when the instance is already destroyed.