### PR TITLE
fix: clear network list fail in ie11

### DIFF
--- a/src/network/network.js
+++ b/src/network/network.js
@@ -130,7 +130,7 @@ class VConsoleNetworkTab extends VConsolePlugin {
 
     // remove dom
     for (let id in this.domList) {
-      this.domList[id].remove();
+      this.domList[id].parentNode.removeChild(this.domList[id]);
       this.domList[id] = undefined;
     }
     this.domList = {};


### PR DESCRIPTION
fix: clear network list fail in ie11