### PR TITLE
fix: cancel selection

### DIFF
--- a/src/core/core.js
+++ b/src/core/core.js
@@ -238,7 +238,7 @@ class VConsole {
         }
         if (needFocus) {
           targetElem.focus();
-        } else {
+        } else if (typeof window.getSelection !== 'function' || !getSelection().rangeCount) {
           e.preventDefault(); // prevent click 300ms later
         }
         let touch = e.changedTouches[0];

--- a/src/core/core.less
+++ b/src/core/core.less
@@ -5,6 +5,7 @@
   color: #000;
   font-size: @fontSize;
   font-family: Helvetica Neue, Helvetica, Arial, sans-serif;
+  -webkit-user-select: auto;
 
 
   /* global */


### PR DESCRIPTION
反选文本时会取消不了选区，原因是在 touchend 里被 preventDefault