### PR TITLE
update plugin list: add vconsole-stats-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ English | [简体中文](./README_CN.md)
 
 vConsole
 ==============================
-[![npm version](https://badge.fury.io/js/vconsole.svg)](https://badge.fury.io/js/vconsole) 
+[![npm version](https://badge.fury.io/js/vconsole.svg)](https://badge.fury.io/js/vconsole)
 
 A lightweight, extendable front-end developer tool for mobile web page.
 
@@ -75,7 +75,7 @@ Plugin:
 
  - [vConsole-sources](https://github.com/WechatFE/vConsole-sources)
  - [vconsole-webpack-plugin](https://github.com/diamont1001/vconsole-webpack-plugin)
- 
+ - [vconsole-stats-plugin](https://github.com/smackgg/vConsole-Stats)
 
 ## Changelog
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -2,7 +2,7 @@
 
 vConsole
 ==============================
-[![npm version](https://badge.fury.io/js/vconsole.svg)](https://badge.fury.io/js/vconsole) 
+[![npm version](https://badge.fury.io/js/vconsole.svg)](https://badge.fury.io/js/vconsole)
 
 一个轻量、可拓展、针对手机网页的前端开发者调试面板。
 
@@ -78,8 +78,7 @@ vConsole 本体：
 
  - [vConsole-sources](https://github.com/WechatFE/vConsole-sources)
  - [vconsole-webpack-plugin](https://github.com/diamont1001/vconsole-webpack-plugin)
-
-
+ - [vconsole-stats-plugin](https://github.com/smackgg/vConsole-Stats)
 
 ## 更新记录
 


### PR DESCRIPTION
Update plugin list.

vconsole-stats-plugin
- FPS Frames rendered in the last second. The higher the number the better.
- MS Milliseconds needed to render a frame. The lower the number the better.
- MB MBytes of allocated memory. (Run Chrome with --enable-precise-memory-info)
- CUSTOM User-defined panel support.