### PR TITLE
fix nonce searching problem

### DIFF
--- a/src/lib/mito.js
+++ b/src/lib/mito.js
@@ -64,9 +64,14 @@ export default function render(tpl, data, toString) {
   // run code, do NOT use `eval` or `new Function` to avoid `unsafe-eval` CSP rule
   let scriptList = document.getElementsByTagName('script');
   let nonce = '';
-  if (scriptList.length > 0) {
-    nonce = scriptList[0].nonce || ''; // get nonce to avoid `unsafe-inline`
+  // find the first script with nonce
+  for (let script of scriptList) {
+    if (script.nonce) {
+      nonce = script.nonce
+      break
+    }
   }
+  
   let script = document.createElement('SCRIPT');
   script.innerHTML = codeWrap;
   script.setAttribute('nonce', nonce);

--- a/src/log/default.js
+++ b/src/log/default.js
@@ -196,8 +196,12 @@ class VConsoleDefaultTab extends VConsoleLogTab {
     code += '}';
     let scriptList = document.getElementsByTagName('script');
     let nonce = '';
-    if (scriptList.length > 0) {
-      nonce = scriptList[0].nonce || ''; // get nonce to avoid `unsafe-inline`
+    // find the first script with nonce
+    for (let script of scriptList) {
+      if (script.nonce) {
+        nonce = script.nonce
+        break
+      }
     }
     let script = document.createElement('SCRIPT');
     script.innerHTML = code;


### PR DESCRIPTION
### problem

original implementation find the first script without checking if `nonce` exists

for case of scripts that have src, nonce might not be there because they could be set directly with domains. like `script-src: http://domain  nonce-xxx`


```
<script src="remote url"/>
<script noce>
</script>
```