### PR TITLE
fix: babel-loader work incorrectly with .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -5,20 +5,20 @@
       {
         "modules": "umd",
         "targets": {
-          "ie": "9",
-        },
-      },
-    ],
+          "ie": "9"
+        }
+      }
+    ]
   ],
   "plugins": [
     [
       "@babel/plugin-proposal-class-properties",
       {
-        "loose": true,
-      },
+        "loose": true
+      }
     ],
     "@babel/plugin-proposal-export-namespace-from",
     "@babel/plugin-proposal-object-rest-spread",
     "add-module-exports"
-  ],
+  ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,12 +2,13 @@ const pkg = require('./package.json');
 const Webpack = require('webpack');
 const Path = require('path');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
+const fs = require('fs');
 
 module.exports = {
   mode: 'production',
   devtool: false,
   entry: {
-    vconsole : Path.resolve(__dirname, './src/vconsole.js')
+    vconsole: Path.resolve(__dirname, './src/vconsole.js')
   },
   output: {
     path: Path.resolve(__dirname, './dist'),
@@ -19,10 +20,15 @@ module.exports = {
   module: {
     rules: [
       {
-        test: /\.html$/, loader: 'html-loader?minimize=false'
+        test: /\.html$/,
+        loader: 'html-loader?minimize=false'
       },
-      { 
-        test: /\.js$/, loader: 'babel-loader'
+      {
+        test: /\.js$/,
+        loader: 'babel-loader',
+        options: {
+          ...JSON.parse(fs.readFileSync(Path.resolve(__dirname, '.babelrc'))),
+        }
       },
       {
         test: /\.less$/,
@@ -34,7 +40,8 @@ module.exports = {
     colors: true,
   },
   plugins: [
-    new Webpack.BannerPlugin([
+    new Webpack.BannerPlugin(
+      [
         'vConsole v' + pkg.version + ' (' + pkg.homepage + ')',
         '',
         'Tencent is pleased to support the open source community by making vConsole available.',
@@ -42,7 +49,8 @@ module.exports = {
         'Licensed under the MIT License (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at',
         'http://opensource.org/licenses/MIT',
         'Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.'
-    ].join('\n')),
+      ].join('\n')
+    ),
     new CopyWebpackPlugin([
       {
         from: Path.resolve(__dirname, './src/vconsole.d.ts'),


### PR DESCRIPTION
fix #384 

问题产生原因是3.5.0中引用了copy-text-to-clipboard，问题代码在[31行](https://github.com/sindresorhus/copy-text-to-clipboard/blob/main/index.js#L31)，catch块没有携带参数。

这种写法是es2019的提案，babel7已经支持[@babel/plugin-proposal-optional-catch-binding](https://babeljs.io/docs/en/babel-plugin-proposal-optional-catch-binding#docsNav)

在相对老的项目中，比如vue-cli2生成的项目，其中的babel还处在babel6，遇到这种代码便会报错。

根据官网所说，`@babel/preset-env`已经预置了`@babel/plugin-proposal-optional-catch-binding`插件

本项目使用的也是babel7+@babel/preset-env，但是编译出来的代码却还是
```js
try {} catch {}
```
最重搜索得知`babel-loader`好像并不是默认加载`.babelrc`中的配置，[issue1](https://github.com/babel/babel-loader/issues/552)，[issue2](https://github.com/babel/babel-loader/issues/780)