### PR TITLE
修复URL第二个参数为undefined的时IOS12报错的问题

### DIFF
--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -670,7 +670,7 @@ class VConsoleNetworkTab extends VConsolePlugin {
     return ret;
   }
 
-  private getURL(urlString: string) {
+  private getURL(urlString: string = '') {
     if (urlString.includes('http')) {
       return new URL(urlString);
     } else {

--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -670,8 +670,12 @@ class VConsoleNetworkTab extends VConsolePlugin {
     return ret;
   }
 
-  private getURL(urlString: string = '') {
-    return new URL(urlString, urlString.includes('http') ? undefined : window.location.href);
+  private getURL(urlString: string) {
+    if (urlString.includes('http')) {
+      return new URL(urlString);
+    } else {
+      return new URL(urlString, window.location.href);
+    }
   }
 
   /**


### PR DESCRIPTION
https://bugs.webkit.org/show_bug.cgi?id=216841