### PR TITLE
在mockFetch中增加对Request对象的支持

### DIFF
--- a/src/network/network.ts
+++ b/src/network/network.ts
@@ -524,7 +524,9 @@ class VConsoleNetworkTab extends VConsolePlugin {
         }
       }
 
-      return _fetch(url.toString(), init).then((response) => {
+      const request = tool.isString(input) ? url.toString() : input;
+
+      return _fetch(request, init).then((response) => {
         _fetchReponse = response;
 
         item.endTime = +new Date();


### PR DESCRIPTION
原先的`mockFetch`在`input`为`Request`对象时无法正常请求，因为在最后请求时直接使用url的字符串作为第一个参数，默认其他参数会在`init`中，但当`input`为`Request`对象时，其余所需的参数如`body`等不会存在与`init`中，故无法正常请求。