### PR TITLE
fix: vc-cmd bottom style

### DIFF
--- a/src/core/core.less
+++ b/src/core/core.less
@@ -449,7 +449,7 @@
       height: (40em / @font);
       left: 0;
       right: 0;
-      bottom: 41px;
+      bottom: (40em / @font);
       border-top: 1px solid var(--VC-FG-3);
       display: block!important;
       &.vc-filter{


### PR DESCRIPTION
vconsole + flexible.js，在移动端上会导致 command-form 和 filter-form 重叠，原因是`height`用了**em**，`bottom`用了**px**
![image](https://user-images.githubusercontent.com/17154608/126609826-88095d3c-73b4-46b1-8e9a-2e5f3aea3c9f.png)

复现Demo:
```html
<html>
  <head>
    <script src="https://cdn.bootcdn.net/ajax/libs/vConsole/3.9.0/vconsole.min.js"></script>
    <!-- flexible.js -->
    <script src="http://g.tbcdn.cn/mtb/lib-flexible/0.3.2/flexible_css.js"></script>
    <script src="http://g.tbcdn.cn/mtb/lib-flexible/0.3.2/flexible.js"></script>
    <script>
      // VConsole will be exported to `window.VConsole` by default.
      var vConsole = new window.VConsole();
    </script>
    <style>
      form {
        margin-block-end: 0;
      }
    </style>
  </head>
</html>
```