### PR TITLE
fix: fix setAttribute error

### DIFF
--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -214,9 +214,12 @@ class VConsole {
 
   /**
   * Update theme
-  * @private 
+  * @private
   */
   _updateTheme() {
+    if (!this.$dom) {
+      return;
+    }
     let theme = this.option.theme;
     if (theme !== 'light' && theme !== 'dark') {
       theme = ''; // use system theme


### PR DESCRIPTION
vConsole还未初始化完成时，调用setOption方法，报错：Cannot read property 'setAttribute' of null。
复现Demo：
```html
<html>
  <head>
    <script src="https://cdn.bootcdn.net/ajax/libs/vConsole/3.9.1/vconsole.min.js"></script>
    <script>
      var vConsole = new window.VConsole();
      vConsole.setOption('onReady', () => {
        console.log('vConsole setOption is ready')
      })
    </script>
  </head>
</html>
```
错误截图：
![image](https://user-images.githubusercontent.com/30066384/130897735-12b182c9-38ff-4ea0-8691-ebe630fa9c35.png)
