### PR TITLE
fix(log): undefined variables gets logged into vConsole

### DIFF
--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -553,7 +553,7 @@ class VConsoleLogTab extends VConsolePlugin {
           rawLog = String(curLog);
           // log = (logStyle[i] ? `<span style="${logStyle[i]}"> ` : '<span> ') + tool.htmlEncode(curLog).replace(/\n/g, '<br/>') + '</span>';
           log = $.render(tplLineLog, {
-            log: curLog,
+            log: rawLog,
             logStyle: logStyle[i],
             logClass: item.logClass,
           });


### PR DESCRIPTION
Currently, console.log(undefined) is not getting logged into the vConsole log, This PR will fix that issue.