### PR TITLE
feat(Log): print `Error` object details #448

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -302,9 +302,13 @@ export function getFunctionSignature (fn) {
   }
 
   try {
-    const match = fn.toString().match(/\((.*([\r?\n].*)*)\)/);
-    if (match && match[1]) {
-      return `function ${functionName}(${match[1].split(',').map(s => s.trim()).join(', ')})`;
+    const match = fn.toString().match(/\((.*?([\r?\n].*?)*?)\)\s*({|=>)/);
+    if (match) {
+      if (match[3] === '=>') {
+        return `(${match[1] ? match[1].split(',').map(s => s.trim()).join(', ') : ''}) => {...}`;
+      } else {
+        return `function ${functionName}(${match[1] ? match[1].split(',').map(s => s.trim()).join(', ') : ''})`;
+      }
     }
   } catch (_) {}
   return `function ${functionName}()`;

--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -276,14 +276,38 @@ export function getObjAllKeys(obj) {
   if (!isObject(obj) && !isArray(obj)) {
     return [];
   }
-  const keys = [];
+  let keys = [];
   for (let k in obj) {
     // typeof `k` may be `string | number | symbol`
     keys.push(k);
   }
+  if (obj instanceof Error && !Object.prototype.hasOwnProperty.call(obj, 'constructor')) {
+    keys = [...keys, 'message', 'stack'];
+    keys = keys.filter((key, index) => (keys.indexOf(key) === index));
+  }
   return keys.sort((a, b) => {
     return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
   });
+}
+
+export function getFunctionSignature (fn) {
+  if (!isFunction(fn)) {
+    return '';
+  }
+  let functionName;
+  try {
+    functionName = fn.name || '';
+  } catch (_) {
+    functionName = '';
+  }
+
+  try {
+    const match = fn.toString().match(/\((.*([\r?\n].*)*)\)/);
+    if (match && match[1]) {
+      return `function ${functionName}(${match[1].split(',').map(s => s.trim()).join(', ')})`;
+    }
+  } catch (_) {}
+  return `function ${functionName}()`;
 }
 
 /**

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -656,7 +656,7 @@ export class VConsoleLogPlugin extends VConsolePlugin {
               val = 'undefined';
             } else if (tool.isFunction(val)) {
               valueType = 'function';
-              val = 'function()';
+              val = tool.getFunctionSignature(val);
             } else if (tool.isSymbol(val)) {
               valueType = 'symbol';
             }
@@ -699,7 +699,18 @@ export class VConsoleLogPlugin extends VConsolePlugin {
           // render object's prototype
           if (tool.isObject(obj)) {
             let proto = obj.__proto__,
-              $proto;
+              $proto,
+              $constructor;
+            if (Object.prototype.hasOwnProperty.call(obj, 'constructor')) {
+              $constructor = $.render(tplFold, {
+                lineType: 'kv',
+                key: 'constructor',
+                keyType: 'private',
+                value: tool.getFunctionSignature(obj.constructor),
+                valueType: 'function'
+              });
+              $content.insertAdjacentElement('beforeend', $constructor);
+            }
             if (tool.isObject(proto)) {
               $proto = that.getFoldedLine(proto, $.render(tplFoldCode, {
                 key: '__proto__',

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -701,7 +701,7 @@ export class VConsoleLogPlugin extends VConsolePlugin {
             let proto = obj.__proto__,
               $proto,
               $constructor;
-            if (Object.prototype.hasOwnProperty.call(obj, 'constructor')) {
+            if (Object.prototype.hasOwnProperty.call(obj, 'constructor') && typeof obj.constructor === 'function') {
               $constructor = $.render(tplFold, {
                 lineType: 'kv',
                 key: 'constructor',


### PR DESCRIPTION
Error 不显示 stack 真的很影响线上定位问题！

这个 PR 除了修复这个问题，还加上了

- 显示对象原型链 constructor
- 显示对象函数属性的 name 和形参列表，支持运行时未被转义的箭头函数

希望尽快更新 Error 输出为空对象的问题 #448 

效果：

```js
console.error(new TypeError('test'))
```

![image](https://user-images.githubusercontent.com/23353576/144554949-4605a063-a6af-4a6f-a158-c3ba82e6c13a.png)

```js
console.log({ prop: function functionName(aaa,

bbb,

ccc,d) {} })
```

![image](https://user-images.githubusercontent.com/23353576/144555490-92e51d64-2b5b-423f-8b03-9ba4573fd2b0.png)

```js
console.log({ f: (b,

c,
bbbb,


lll,

a) => { return (aaa,bbb,ccc) => {} }  })
```

![image](https://user-images.githubusercontent.com/23353576/144575359-64c3bb36-182a-418b-b7e6-a0347384fff0.png)
