### PR TITLE
fix: Uncaught TypeError: Cannot read properties of undefined (reading 'body')

### DIFF
--- a/src/network/network.model.ts
+++ b/src/network/network.model.ts
@@ -306,7 +306,7 @@ export class VConsoleNetworkModel extends VConsoleModel {
       //     item.postData = '[object Object]';
       //   }
       // }
-      if (init.body) {
+      if (init && init.body) {
         item.postData = that.getFormattedBody(init.body);
       }
 


### PR DESCRIPTION
Click Get Fetch(Simple) has an error
Uncaught TypeError: Cannot read properties of undefined (reading 'body')