### PR TITLE
Fix unclickable `vc-cmd-clear-btn` on iOS Safari

### DIFF
--- a/src/log/logCommand.less
+++ b/src/log/logCommand.less
@@ -17,7 +17,8 @@
 
 // input or textarea
 .vc-cmd-input-wrap {
-  display: block;
+  display: flex;
+  align-items: center;
   position: relative;
   height: (28em / @font);
   margin-right: (40em / @font);
@@ -52,12 +53,8 @@
   font-size: 1em;
 }
 .vc-cmd-clear-btn {
-  position: absolute;
+  flex: 1 (40em / @font);
   text-align: center;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  width: (40em / @font);
   line-height: (40em / @font);
 }
 .vc-cmd-btn:active,

--- a/src/log/logCommand.svelte
+++ b/src/log/logCommand.svelte
@@ -236,11 +236,6 @@
   </ul>
 
   <div class="vc-cmd-input-wrap">
-    {#if cmdValue.length > 0}
-      <div class="vc-cmd-clear-btn" on:click|preventDefault={() => onTapClearText('cmd')}>
-        <Icon name="clear" />
-      </div>
-    {/if}
     <textarea
       class="vc-cmd-input"
       placeholder="command..."
@@ -251,6 +246,11 @@
       on:focus={onCmdFocus}
       on:blur={onCmdBlur}
     ></textarea>
+    {#if cmdValue.length > 0}
+    <div class="vc-cmd-clear-btn" on:click|preventDefault={() => onTapClearText('cmd')}>
+      <Icon name="clear" />
+    </div>
+  {/if}
   </div>
 </form>
 
@@ -258,15 +258,15 @@
   <button class="vc-cmd-btn" type="submit">Filter</button>
   <ul class='vc-cmd-prompted'></ul>
   <div class="vc-cmd-input-wrap">
-    {#if filterValue.length > 0}
-      <div class="vc-cmd-clear-btn" on:click|preventDefault={() => onTapClearText('filter')}>
-        <Icon name="clear" />
-      </div>
-    {/if}
     <textarea
       class="vc-cmd-input"
       placeholder="filter..."
       bind:value={filterValue}
     ></textarea>
+    {#if filterValue.length > 0}
+    <div class="vc-cmd-clear-btn" on:click|preventDefault={() => onTapClearText('filter')}>
+      <Icon name="clear" />
+    </div>
+  {/if}
   </div>
 </form>


### PR DESCRIPTION
fix #565 