### PR TITLE
支持虚拟滚动

### DIFF
--- a/doc/plugin_event_list.md
+++ b/doc/plugin_event_list.md
@@ -26,7 +26,13 @@ Trigger while vConsole trying to create a new tab for a plugin. This event will 
 After binding this event, vConsole will get HTML from your callback to render a tab. A new tab will definitely be added if you bind this event, no matter what tab's HTML you set. Do not bind this event if you don't want to add a new tab.
 
 ##### Callback Arguments:
-- (required) function(html): a callback function that receives the content HTML of the new tab. `html` can be a HTML `string` or an `HTMLElement` object (Or object which supports `appendTo()` method, like JQuery object).
+- (required) function(html, options): a callback function that receives the content HTML of the new tab. `html` can be a HTML `string` or an `HTMLElement` object (Or object which supports `appendTo()` method, like JQuery object), and an optional `object` for tab options.
+
+A tab option is an object with properties:
+
+Property |         |         |        |
+------- | ------- | ------- | -------
+fixedHeight | boolean | optional | Whether the height of tab is fixed to 100%.
 
 ##### Example:
 

--- a/doc/plugin_event_list_CN.md
+++ b/doc/plugin_event_list_CN.md
@@ -33,7 +33,13 @@ myPlugin.on('init', function() {
 绑定此事件后，vConsole 会认为此插件需要创建新 tab，并会将 callback 中获取的 HTML 用于渲染 tab。因此，只要绑定了此事件，新 tab 肯定会被渲染到页面中，无论 callback 传入的 HTML 是否为空。如果不需要添加新 tab，请不要绑定此事件。
 
 ##### Callback 参数
-- (必填) function(html): 回调函数，接收一个 HTML 参数用于渲染 tab。`html` 可以为 HTML 字符串，或者 `HTMLElement` 对象（或支持 `appendTo()` 方法的对象，如 jQuery 对象）。
+- (必填) function(html, options): 回调函数，第一个参数接收一个 HTML 参数用于渲染 tab。`html` 可以为 HTML 字符串，或者 `HTMLElement` 对象（或支持 `appendTo()` 方法的对象，如 jQuery 对象）。第二个参数接收一个可选配置信息。
+
+配置的参数为：
+
+Property | | | |
+------- | ------- | ------- | -------
+fixedHeight | boolean | 选填 | tab 高度固定为 100%。
 
 ##### 例子：
 

--- a/src/component/recycleScroller/recycleItem.svelte
+++ b/src/component/recycleScroller/recycleItem.svelte
@@ -28,7 +28,7 @@
   bind:this={item}
   class="vc-scroller-item"
   style:display={show ? "block" : "none"}
-  style:transform="translateY({top}px) translateZ(0)"
+  style:top="{top}px"
 >
   <slot />
 </div>

--- a/src/component/recycleScroller/recycleItem.svelte
+++ b/src/component/recycleScroller/recycleItem.svelte
@@ -1,0 +1,34 @@
+<script lang="ts">
+  import { onMount, onDestroy } from 'svelte';
+
+  export let show: boolean
+  export let top: boolean
+
+  export let onResize: (height: number) => void = () => {}
+
+  let item: HTMLDivElement | undefined
+
+  let observer: ResizeObserver | null = null
+
+  onMount(() => {
+    if (show) onResize(item.getBoundingClientRect().height)
+    observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (show) onResize(entry.contentRect.height)
+    })
+    observer.observe(item)
+  });
+
+  onDestroy(() => {
+    observer.disconnect()
+  });
+</script>
+
+<div
+  bind:this={item}
+  class="vc-scroller-item"
+  style:display={show ? "block" : "none"}
+  style:transform="translateY({top}px) translateZ(0)"
+>
+  <slot />
+</div>

--- a/src/component/recycleScroller/recycleManager.ts
+++ b/src/component/recycleScroller/recycleManager.ts
@@ -1,0 +1,161 @@
+const createRecycleManager = () => {
+  const recycles: { key: number; index: number; show: boolean }[] = [];
+
+  const poolKeys: number[] = [];
+  let poolStartIndex = 0;
+  let poolEndIndex = 0;
+
+  let lastItemCount = 0;
+  let lastStart = 0;
+  let lastEnd = 0;
+
+  const update = (itemCount: number, start: number, end: number) => {
+    if (lastItemCount === itemCount && lastStart === start && lastEnd === end)
+      return recycles;
+
+    const poolCount = poolKeys.length;
+
+    // 计算新的 visible 区域
+    const newFirstPool =
+      start <= poolEndIndex
+        ? // 1. 开头一定在 [0, start]
+          Math.max(
+            0,
+            Math.min(
+              start,
+              // 2. 开头一定在 [poolStartIndex, poolEndIndex) 之间
+              Math.max(
+                poolStartIndex,
+                Math.min(poolEndIndex - 1, end - poolCount)
+              )
+            )
+          )
+        : start; // poolEndIndex 如果比 start 小，则前部无法保留下来
+
+    const newLastPool =
+      poolStartIndex <= end
+        ? // 1. 结尾一定在 [end, itemCount] 之间
+          Math.max(
+            end,
+            Math.min(
+              itemCount,
+              // 2. 结尾一定在 (poolStartIndex, poolEndIndex] 之间
+              Math.max(
+                poolStartIndex + 1,
+                Math.min(poolEndIndex, newFirstPool + poolCount)
+              )
+            )
+          )
+        : end; // end 如果比 poolStartIndex 小，则后部无法保留下来
+
+    if (poolCount === 0 || newLastPool - newFirstPool < poolCount) {
+      // 无法复用，全都重新生成
+      const count = (recycles.length = poolKeys.length = end - start);
+      for (let i = 0; i < count; i += 1) {
+        poolKeys[i] = i;
+        recycles[i] = {
+          key: i,
+          index: i + start,
+          show: true,
+        };
+      }
+      poolStartIndex = start;
+      poolEndIndex = end;
+      lastItemCount = itemCount;
+      lastStart = start;
+      lastEnd = end;
+      return recycles;
+    }
+
+    let usedPoolIndex = 0;
+    let usedPoolOffset = 0;
+
+    // 复用区域
+    let reuseStart = 0;
+    let reuseEnd = 0;
+
+    if (poolEndIndex < newFirstPool || newLastPool < poolStartIndex) {
+      // 完全没有交集，随便复用
+      reuseStart = newFirstPool;
+      reuseEnd = newFirstPool + poolCount;
+    } else if (poolStartIndex < newFirstPool) {
+      // 开头复用
+      usedPoolOffset = newFirstPool - poolStartIndex;
+      reuseStart = newFirstPool;
+      reuseEnd = newFirstPool + poolCount;
+    } else if (newLastPool < poolEndIndex) {
+      // 尾部复用
+      usedPoolOffset = poolCount - (poolEndIndex - newLastPool);
+      reuseStart = newLastPool - poolCount;
+      reuseEnd = newLastPool;
+    } else if (newFirstPool <= poolStartIndex && poolEndIndex <= newLastPool) {
+      // 新的 visible 是完全子集，直接复用
+      reuseStart = poolStartIndex;
+      reuseEnd = poolEndIndex;
+    }
+
+    // 开头不可见区域
+    // 如果有不可见区域，则一定是来自上一次 visible 的复用 row
+    for (let i = newFirstPool; i < start; i += 1, usedPoolIndex += 1) {
+      const poolKey = poolKeys[(usedPoolOffset + usedPoolIndex) % poolCount];
+      const recycle = recycles[i - newFirstPool];
+      recycle.key = poolKey;
+      recycle.index = i;
+      recycle.show = false;
+    }
+
+    // 可见区域
+    for (let i = start, keyIndex = 0; i < end; i += 1) {
+      let poolKey: number;
+      if (reuseStart <= i && i < reuseEnd) {
+        // 复用 row
+        poolKey = poolKeys[(usedPoolOffset + usedPoolIndex) % poolCount];
+        usedPoolIndex += 1;
+      } else {
+        // 新建 row
+        poolKey = poolCount + keyIndex;
+        keyIndex += 1;
+      }
+      const recycleIndex = i - newFirstPool;
+      if (recycleIndex < recycles.length) {
+        const recycle = recycles[recycleIndex];
+        recycle.key = poolKey;
+        recycle.index = i;
+        recycle.show = true;
+      } else {
+        recycles.push({
+          key: poolKey,
+          index: i,
+          show: true,
+        });
+      }
+    }
+
+    // 末尾不可见区域
+    // 如果有不可见区域，则一定是来自上一次 visible 的复用 row
+    for (let i = end; i < newLastPool; i += 1, usedPoolIndex += 1) {
+      const poolKey = poolKeys[(usedPoolOffset + usedPoolIndex) % poolCount];
+      const recycle = recycles[i - newFirstPool];
+      recycle.key = poolKey;
+      recycle.index = i;
+      recycle.show = false;
+    }
+
+    // 更新 poolKeys
+    for (let i = 0; i < recycles.length; i += 1) {
+      poolKeys[i] = recycles[i].key;
+    }
+    recycles.sort((a, b) => a.key - b.key);
+    poolStartIndex = newFirstPool;
+    poolEndIndex = newLastPool;
+    lastItemCount = itemCount;
+    lastStart = start;
+    lastEnd = end;
+
+    return recycles;
+  };
+
+  return update;
+};
+
+export default createRecycleManager;

--- a/src/component/recycleScroller/recycleScroller.less
+++ b/src/component/recycleScroller/recycleScroller.less
@@ -1,0 +1,25 @@
+.vc-scroller-viewport {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.vc-scroller-contents {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.vc-scroller-header {
+
+}
+
+.vc-scroller-items {
+  flex: 1;
+}
+
+.vc-scroller-footer {
+
+}

--- a/src/component/recycleScroller/recycleScroller.less
+++ b/src/component/recycleScroller/recycleScroller.less
@@ -9,10 +9,6 @@
   will-change: transform;
 }
 
-.vc-scroller-header {
-
-}
-
 .vc-scroller-items {
   will-change: height;
 }
@@ -22,8 +18,25 @@
   position: absolute;
   left: 0;
   right: 0;
+  will-change: transform;
 }
 
 .vc-scroller-footer {
 
+}
+
+.vc-scroller-scrollbar-track {
+  width: 4px;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  padding: 1px;
+}
+
+.vc-scroller-scrollbar-thumb {
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,.5);
+  border-radius: 999px;
 }

--- a/src/component/recycleScroller/recycleScroller.less
+++ b/src/component/recycleScroller/recycleScroller.less
@@ -1,15 +1,12 @@
 .vc-scroller-viewport {
   position: relative;
   overflow: hidden;
-  display: flex;
-  flex-direction: column;
   height: 100%;
 }
 
 .vc-scroller-contents {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
+  min-height: 100%;
+  will-change: transform;
 }
 
 .vc-scroller-header {
@@ -17,7 +14,14 @@
 }
 
 .vc-scroller-items {
-  flex: 1;
+  will-change: height;
+}
+
+.vc-scroller-item {
+  display: none;
+  position: absolute;
+  left: 0;
+  right: 0;
 }
 
 .vc-scroller-footer {

--- a/src/component/recycleScroller/recycleScroller.less
+++ b/src/component/recycleScroller/recycleScroller.less
@@ -18,7 +18,6 @@
   position: absolute;
   left: 0;
   right: 0;
-  will-change: transform;
 }
 
 .vc-scroller-footer {
@@ -35,6 +34,7 @@
 }
 
 .vc-scroller-scrollbar-thumb {
+  position: relative;
   width: 100%;
   height: 100%;
   background: rgba(0,0,0,.5);

--- a/src/component/recycleScroller/recycleScroller.svelte
+++ b/src/component/recycleScroller/recycleScroller.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { onMount, onDestroy, tick } from "svelte";
+  import RecycleItem from "./recycleItem.svelte";
   import ScrollHandler from "./scroll/scrollHandler";
   import TouchTracker from "./scroll/touchTracker";
   import Style from "./recycleScroller.less";
@@ -8,39 +9,31 @@
   export let items: any[];
   export let itemHeight = undefined;
   export let buffer = 200;
+  export let stickToBottom = false;
 
   // read-only, but visible to consumers via bind:start
   export let start = 0;
   export let end = 0;
 
   // local state
-  let header: HTMLElement | undefined;
   let footer: HTMLElement | undefined;
   let viewport: HTMLElement | undefined;
   let contents: HTMLElement | undefined;
   let frame: HTMLElement | undefined;
-  let rows: HTMLElement[] = [];
 
-  let headerHeight = 0;
   let footerHeight = 0;
   let viewportHeight = 0;
   let frameHeight = 0;
-  let contentsHeight = 0;
 
-  let oldItems = [];
   let heightMap = [];
-  let visible: { key: number, index: number, data: any, show: boolean }[] = [];
-  let mounted;
-  let lastStart = 0;
-
-  let top = 0;
-  let bottom = 0;
+  let topMap = [];
+  let visible: { key: number; index: number; data: any; show: boolean }[] = [];
 
   const getVisible = (start, end) => {
-    // ;(window as any)._vcOrigConsole.log('getVisible', start, end)
-    const newVisible = []
+    // (window as any)._vcOrigConsole.log("getVisible", start, end);
+    const newVisible = [];
     // const visibleCount = end - start
-    const poolCount = visible.length
+    const poolCount = visible.length;
     // ;(window as any)._vcOrigConsole.log('poolCount', poolCount)
 
     if (poolCount === 0) {
@@ -50,29 +43,46 @@
           index: i,
           data: items[i],
           show: true,
-        })
+        });
       }
-      return newVisible
+      return newVisible;
     }
 
-    const firstPool = visible[0].index
-    const lastPool = visible[poolCount - 1].index + 1
+    const firstPool = visible[0].index;
+    const lastPool = visible[poolCount - 1].index + 1;
 
     // ;(window as any)._vcOrigConsole.log('firstPool', firstPool)
     // ;(window as any)._vcOrigConsole.log('lastPool', lastPool)
 
     // 计算新的 visible 区域
-    const newFirstPool = start <= lastPool
-      // 1. 开头一定在 [0, start]
-      // 2. 开头一定在 [firstPool, lastPool) 之间
-      ? Math.max(0, Math.min(start, Math.max(firstPool, Math.min(lastPool - 1, end - poolCount))))
-      : start // lastPool 如果比 start 小，则前部无法保留下来
+    const newFirstPool =
+      start <= lastPool
+        ? // 1. 开头一定在 [0, start]
+          Math.max(
+            0,
+            Math.min(
+              start,
+              // 2. 开头一定在 [firstPool, lastPool) 之间
+              Math.max(firstPool, Math.min(lastPool - 1, end - poolCount))
+            )
+          )
+        : start; // lastPool 如果比 start 小，则前部无法保留下来
 
-    const newLastPool = firstPool <= end
-      // 1. 结尾一定在 [end, items.length] 之间
-      // 2. 结尾一定在 (firstPool, lastPool] 之间
-      ? Math.max(end, Math.min(items.length, Math.max(firstPool + 1, Math.min(lastPool, newFirstPool + poolCount))))
-      : end // end 如果比 firstPool 小，则后部无法保留下来
+    const newLastPool =
+      firstPool <= end
+        ? // 1. 结尾一定在 [end, items.length] 之间
+          Math.max(
+            end,
+            Math.min(
+              items.length,
+              // 2. 结尾一定在 (firstPool, lastPool] 之间
+              Math.max(
+                firstPool + 1,
+                Math.min(lastPool, newFirstPool + poolCount)
+              )
+            )
+          )
+        : end; // end 如果比 firstPool 小，则后部无法保留下来
 
     // ;(window as any)._vcOrigConsole.log('newFirstPool', newFirstPool)
     // ;(window as any)._vcOrigConsole.log('newLastPool', newLastPool)
@@ -85,36 +95,36 @@
           index: i,
           data: items[i],
           show: true,
-        })
+        });
       }
-      return newVisible
+      return newVisible;
     }
 
-    let usedPoolIndex = 0
-    let usedPoolOffset = 0
+    let usedPoolIndex = 0;
+    let usedPoolOffset = 0;
 
     // 复用区域
-    let reuseStart = 0
-    let reuseEnd = 0
+    let reuseStart = 0;
+    let reuseEnd = 0;
 
     if (lastPool < newFirstPool || newLastPool < firstPool) {
       // 完全没有交集，随便复用
-      reuseStart = newFirstPool
-      reuseEnd = newFirstPool + poolCount
+      reuseStart = newFirstPool;
+      reuseEnd = newFirstPool + poolCount;
     } else if (firstPool < newFirstPool) {
       // 开头复用
-      usedPoolOffset = newFirstPool - firstPool
-      reuseStart = newFirstPool
-      reuseEnd = newFirstPool + poolCount
+      usedPoolOffset = newFirstPool - firstPool;
+      reuseStart = newFirstPool;
+      reuseEnd = newFirstPool + poolCount;
     } else if (newLastPool < lastPool) {
       // 尾部复用
-      usedPoolOffset = poolCount - (lastPool - newLastPool)
-      reuseStart = newLastPool - poolCount
-      reuseEnd = newLastPool
+      usedPoolOffset = poolCount - (lastPool - newLastPool);
+      reuseStart = newLastPool - poolCount;
+      reuseEnd = newLastPool;
     } else if (newFirstPool <= firstPool && lastPool <= newLastPool) {
       // 新的 visible 是完全子集，直接复用
-      reuseStart = firstPool
-      reuseEnd = lastPool
+      reuseStart = firstPool;
+      reuseEnd = lastPool;
     }
 
     // ;(window as any)._vcOrigConsole.log('usedPoolIndex', usedPoolIndex)
@@ -125,55 +135,56 @@
     // 开头不可见区域
     // 如果有不可见区域，则一定是来自上一次 visible 的复用 row
     for (let i = newFirstPool; i < start; i += 1, usedPoolIndex += 1) {
-      const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount]
+      const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount];
       newVisible.push({
         key: pool.key,
         index: i,
         data: items[i],
         show: false,
-      })
+      });
     }
 
     // 可见区域
     for (let i = start, keyIndex = 0; i < end; i += 1) {
-      let key
+      let key;
       if (reuseStart <= i && i < reuseEnd) {
         // 复用 row
-        const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount]
-        key = pool.key
-        usedPoolIndex += 1
+        const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount];
+        key = pool.key;
+        usedPoolIndex += 1;
       } else {
         // 新建 row
-        key = poolCount + keyIndex
-        keyIndex += 1
+        key = poolCount + keyIndex;
+        keyIndex += 1;
       }
       newVisible.push({
         key,
         index: i,
         data: items[i],
         show: true,
-      })
+      });
     }
 
     // 末尾不可见区域
     // 如果有不可见区域，则一定是来自上一次 visible 的复用 row
     for (let i = end; i < newLastPool; i += 1, usedPoolIndex += 1) {
-      const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount]
+      const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount];
       newVisible.push({
         key: pool.key,
         index: i,
         data: items[i],
         show: false,
-      })
+      });
     }
 
-    return newVisible
-  }
+    return newVisible;
+  };
 
-  const getScrollExtent = () => Math.max(0, contentsHeight - viewportHeight);
+  const getScrollExtent = () =>
+    Math.max(0, frameHeight + footerHeight - viewportHeight);
 
   let isOnBottom = true;
-  let avoidRefresh = false
+  let avoidRefresh = false;
 
   const scrollHandler = new ScrollHandler(getScrollExtent, (pos) => {
     // if (pos < 0) {
@@ -184,9 +195,9 @@
 
     // refresh first to avoid recaculating styles caused by changing transform styles below.
     if (avoidRefresh) {
-      avoidRefresh = false
+      avoidRefresh = false;
     } else {
-      refresh(items, pos, viewportHeight, headerHeight);
+      refresh(items, pos, viewportHeight);
     }
 
     const transform = `translateY(${-pos}px) translateZ(0)`;
@@ -196,104 +207,97 @@
   const scrollToBottom = (force?: boolean) => {
     const maxScrollHeight = getScrollExtent();
     if (force || scrollHandler.getPosition() > maxScrollHeight) {
+      // (window as any)._vcOrigConsole.log(
+      //   "scrollToBottom",
+      //   force,
+      //   scrollHandler.getPosition() > maxScrollHeight,
+      //   maxScrollHeight
+      // );
       scrollHandler.updatePosition(maxScrollHeight);
     }
   };
 
   function initItems(items) {
-    return init(items, viewportHeight, itemHeight, headerHeight);
+    return init(items, viewportHeight, itemHeight);
   }
+
+  let oldItems = [];
+  let mounted;
 
   // whenever `items` or `itemHeight` changes, refresh the viewport
   $: if (mounted) initItems(items);
 
-  function init(items, viewportHeight, itemHeight, headerHeight) {
+  function init(items, viewportHeight, itemHeight) {
     // preserve heightMap
     const itemsHeightMap = new Map<any, number>();
-    heightMap = [];
 
-    // ;(window as any)._vcOrigConsole.log('init');
-    let reuseHeightCount = 0
+    // (window as any)._vcOrigConsole.log("init");
+    // let reuseHeightCount = 0;
 
     for (let i = 0; i < oldItems.length; i += 1) {
-      itemsHeightMap[oldItems[i]] = heightMap[i];
+      itemsHeightMap.set(oldItems[i], heightMap[i]);
     }
+    topMap.length = heightMap.length = items.length;
+    let y = 0;
     for (let i = 0; i < items.length; i += 1) {
       const item = items[i];
       if (itemsHeightMap.has(item)) {
-        heightMap.push(itemsHeightMap.get(item));
-        reuseHeightCount += 1
+        heightMap[i] = itemsHeightMap.get(item);
+        // reuseHeightCount += 1;
       } else {
-        heightMap.push(itemHeight);
+        heightMap[i] = itemHeight;
       }
+      topMap[i] = y;
+      y += heightMap[i];
     }
+    frameHeight = Math.max(y, viewportHeight - footerHeight);
 
-    // ;(window as any)._vcOrigConsole.log('reuseHeightCount', reuseHeightCount);
-    // ;(window as any)._vcOrigConsole.log('new height count', items.length -= reuseHeightCount);
+    // (window as any)._vcOrigConsole.log("heightMap", heightMap);
+    // (window as any)._vcOrigConsole.log("reuseHeightCount", reuseHeightCount);
+    // (window as any)._vcOrigConsole.log(
+    //   "new height count",
+    //   items.length - reuseHeightCount
+    // );
 
     oldItems = items;
 
-    if (viewportHeight === 0) {
-      // viewport is not visible
-      return refresh([], 0, 0, 0);
-    }
-
-    refresh(
-      items,
-      scrollHandler.getPosition(),
-      viewportHeight,
-      headerHeight
-    );
-
-    scrollToBottom(isOnBottom);
+    refresh(items, scrollHandler.getPosition(), viewportHeight);
+    frame.style.height = `${frameHeight}px`;
+    scrollToBottom(isOnBottom && stickToBottom);
   }
 
-  let refreshing = false;
+  function refresh(items: any[], scrollTop: number, viewportHeight: number) {
+    // (window as any)._vcOrigConsole.error(
+    //   "refresh",
+    //   items.length,
+    //   scrollTop,
+    //   viewportHeight
+    // );
 
-  function refresh(
-    items: any[],
-    scrollTop: number,
-    viewportHeight: number,
-    headerHeight: number
-  ) {
-    if (refreshing) return;
-    refreshing = true;
-    // ;(window as any)._vcOrigConsole.log('refresh begin');
+    let i = 0;
+    let y = 0;
 
-    try {
-      let oldStart = start;
-      let oldEnd = end;
-
-      let i = 0;
-      let y = headerHeight;
-
-      while (i < items.length && y + heightMap[i] < scrollTop - buffer) {
-        y += heightMap[i];
-        i += 1;
-      }
-
-      start = i;
-      top = y - headerHeight;
-
-      while (i < items.length && y < scrollTop + viewportHeight + buffer) {
-        y += heightMap[i];
-        i += 1;
-      }
-
-      end = i;
-
-      let newBottom = 0;
-      for (; i < items.length; i += 1) newBottom += heightMap[i];
-      bottom = newBottom;
-
-      if (start === oldStart && end === oldEnd) return;
-
-      visible = getVisible(start, end);
-      lastStart = oldStart
-    } finally {
-      // ;(window as any)._vcOrigConsole.log('refresh complete');
-      refreshing = false;
+    while (i < items.length && y + heightMap[i] < scrollTop - buffer) {
+      y += heightMap[i];
+      i += 1;
     }
+    // (window as any)._vcOrigConsole.error("refresh start", i, y);
+
+    start = i;
+
+    while (
+      i < items.length &&
+      viewportHeight &&
+      y < scrollTop + viewportHeight + buffer
+    ) {
+      y += heightMap[i];
+      i += 1;
+    }
+    // (window as any)._vcOrigConsole.error("refresh end", i, y);
+
+    end = i;
+
+    visible = getVisible(start, end);
   }
 
   const registerHeightObserver = (
@@ -341,50 +345,19 @@
       viewportHeight = height;
 
       // setTimeout to avoid ResizeObserver loop limit exceeded error
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       if (oldViewportHeight === 0) {
         // viewport invisible to visible
-        refresh(
-          items,
-          scrollHandler.getPosition(),
-          viewportHeight,
-          headerHeight
-        );
-        scrollToBottom(isOnBottom);
+        refresh(items, scrollHandler.getPosition(), viewportHeight);
+        scrollToBottom(isOnBottom && stickToBottom);
       } else if (viewportHeight === 0) {
         // visible to invisible
-        refresh([], 0, 0, 0);
+        refresh(items, scrollHandler.getPosition(), viewportHeight);
       } else {
-        scrollToBottom(isOnBottom);
-        refresh(
-          items,
-          scrollHandler.getPosition(),
-          viewportHeight,
-          headerHeight
-        );
+        scrollToBottom(isOnBottom && stickToBottom);
+        refresh(items, scrollHandler.getPosition(), viewportHeight);
       }
-    }
-  );
-
-  registerHeightObserver(
-    () => header,
-    async (height) => {
-      if (headerHeight === height) return;
-      // (window as any)._vcOrigConsole.log("header height resize", height);
-      // simply refresh is header height changes
-      headerHeight = height;
-
-      // setTimeout to avoid ResizeObserver loop limit exceeded error
-      await new Promise(resolve => setTimeout(resolve, 0))
-
-      scrollToBottom();
-      refresh(
-        items,
-        scrollHandler.getPosition(),
-        viewportHeight,
-        headerHeight
-      );
     }
   );
 
@@ -398,57 +371,43 @@
     }
   );
 
-  registerHeightObserver(
-    () => contents,
-    (height) => {
-      if (contentsHeight === height) return;
-      contentsHeight = height;
+  const onRowResize = async (index: number, height: number) => {
+    if (heightMap[index] === height || viewportHeight === 0) return;
+
+    // (window as any)._vcOrigConsole.log(
+    //   "row resize",
+    //   index,
+    //   heightMap[index],
+    //   height
+    // );
+
+    const oldHeight = heightMap[index];
+    heightMap[index] = height;
+
+    const n = items.length;
+    for (let i = index; i < n - 1; i += 1) {
+      topMap[i + 1] = topMap[i] + heightMap[i];
     }
-  );
+    frameHeight = Math.max(
+      topMap[n - 1] + heightMap[n - 1],
+      viewportHeight - footerHeight
+    );
 
-  registerHeightObserver(
-    () => frame,
-    async (height) => {
-      if (frameHeight === height) return;
-      // ;(window as any)._vcOrigConsole.log('frame height resize', frameHeight, height);
-      // when item height changes, we need to refresh
-      if (refreshing) return; // refresh process will cause content height change
+    const scrollPos = scrollHandler.getPosition();
 
-      frameHeight = height;
-
-      let scrollOffset = 0
-
-      // update row actual height
-      for (let i = 0; i < visible.length; i += 1) {
-        const info = visible[i]
-        if (!info.show) continue
-
-        const row = rows[i];
-        const rowHeight = row?.getBoundingClientRect().height ?? itemHeight;
-        const index = info.index
-        if (index < lastStart) {
-          scrollOffset += rowHeight - heightMap[index]
-        }
-        heightMap[index] = rowHeight;
-        frameHeight += rowHeight;
-      }
-
-      // ;(window as any)._vcOrigConsole.log('frame height refresh');
-      const maxScrollHeight = getScrollExtent();
-      const pos = scrollHandler.getPosition()
-      if (scrollOffset || pos > maxScrollHeight) {
-        // if (scrollOffset) {
-        //   ;(window as any)._vcOrigConsole.log('scrollOffset', scrollOffset);
-        // }
-        avoidRefresh = true
-        scrollHandler.updatePosition(Math.min(maxScrollHeight, pos + scrollOffset));
-      }
-
-      // setTimeout to avoid ResizeObserver loop limit exceeded error
-      await new Promise(resolve => setTimeout(resolve, 0))
-      refresh(items, pos, viewportHeight, headerHeight);
+    avoidRefresh = true;
+    if (topMap[index] + oldHeight < scrollPos) {
+      scrollHandler.updatePosition(scrollPos + height - oldHeight);
+    } else {
+      scrollToBottom(isOnBottom && stickToBottom);
     }
-  );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // (window as any)._vcOrigConsole.log("frameHeight", frameHeight);
+    refresh(items, scrollHandler.getPosition(), viewportHeight);
+    frame.style.height = `${frameHeight}px`;
+  };
 
   // trigger initial refresh
   onMount(() => {
@@ -461,6 +420,15 @@
   });
 
   const touchTracker = new TouchTracker(scrollHandler);
+
+  export const handler = {
+    scrollTo: (index: number, duration?: number) => {
+      const itemPos = topMap[Math.max(0, Math.min(items.length - 1, index))]
+      const scrollPos = Math.min(getScrollExtent(), itemPos)
+
+      scrollHandler.scrollTo(scrollPos, duration)
+    },
+  }
 </script>
 
 <div
@@ -473,26 +441,16 @@
   class="vc-scroller-viewport"
 >
   <div bind:this={contents} class="vc-scroller-contents">
-    {#if $$slots.header}
-      <div bind:this={header} class="vc-scroller-header">
-        <slot name="header" />
-      </div>
-    {/if}
-    <div
-      bind:this={frame}
-      class="vc-scroller-items"
-      style:margin-top="{top}px"
-      style:margin-bottom="{bottom}px"
-    >
+    <div bind:this={frame} class="vc-scroller-items">
       {#if items.length}
         {#each visible as row, i (row.key)}
-          <div
-            bind:this={rows[i]}
-            class="vc-scroller-item"
-            style:display={row.show ? "block" : "none"}
+          <RecycleItem
+            show={row.show}
+            top={topMap[row.index]}
+            onResize={(height) => onRowResize(row.index, height)}
           >
             <slot name="item" item={row.data}>Missing template</slot>
-          </div>
+          </RecycleItem>
         {/each}
       {:else}
         <slot name="empty" />

--- a/src/component/recycleScroller/recycleScroller.svelte
+++ b/src/component/recycleScroller/recycleScroller.svelte
@@ -234,9 +234,9 @@
 
   const refreshScrollbar = () => {
     const pos = scrollHandler.getPosition();
-    const fac = viewportHeight / (frameHeight + footerHeight);
+    const fac = 100 / (frameHeight + footerHeight);
     scrollbarThumbPos = pos * fac;
-    scrollbarThumbHeight = 100 * fac;
+    scrollbarThumbHeight = viewportHeight * fac;
   };
 
   const scrollToBottom = (force?: boolean) => {
@@ -515,7 +515,7 @@
       <div
         class="vc-scroller-scrollbar-thumb"
         style:height="{scrollbarThumbHeight}%"
-        style:transform="translateY({scrollbarThumbPos}px) translateZ(0)"
+        style:top="{scrollbarThumbPos}%"
       />
     </div>
   {/if}

--- a/src/component/recycleScroller/recycleScroller.svelte
+++ b/src/component/recycleScroller/recycleScroller.svelte
@@ -226,7 +226,7 @@
     if (avoidRefresh) {
       avoidRefresh = false;
     } else {
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await new Promise((resolve) => setTimeout(resolve, 0));
 
       refresh(items, pos, viewportHeight, false);
     }
@@ -467,9 +467,20 @@
   const touchTracker = new TouchTracker(scrollHandler);
 
   export const handler = {
-    scrollTo: (index: number, duration?: number) => {
+    scrollTo: (index: number) => {
       const itemPos = topMap[Math.max(0, Math.min(items.length - 1, index))];
       const scrollPos = Math.min(getScrollExtent(), itemPos);
+
+      const maxDuration = 500;
+      const minPixelsPerSecond = 2000;
+
+      const duration = Math.min(
+        Math.floor(
+          (maxDuration * Math.abs(scrollHandler.getPosition() - scrollPos)) /
+            minPixelsPerSecond
+        ),
+        maxDuration
+      );
 
       scrollHandler.scrollTo(scrollPos, duration);
     },

--- a/src/component/recycleScroller/recycleScroller.svelte
+++ b/src/component/recycleScroller/recycleScroller.svelte
@@ -1,0 +1,507 @@
+<script lang="ts">
+  import { onMount, onDestroy, tick } from "svelte";
+  import ScrollHandler from "./scroll/scrollHandler";
+  import TouchTracker from "./scroll/touchTracker";
+  import Style from "./recycleScroller.less";
+
+  // props
+  export let items: any[];
+  export let itemHeight = undefined;
+  export let buffer = 200;
+
+  // read-only, but visible to consumers via bind:start
+  export let start = 0;
+  export let end = 0;
+
+  // local state
+  let header: HTMLElement | undefined;
+  let footer: HTMLElement | undefined;
+  let viewport: HTMLElement | undefined;
+  let contents: HTMLElement | undefined;
+  let frame: HTMLElement | undefined;
+  let rows: HTMLElement[] = [];
+
+  let headerHeight = 0;
+  let footerHeight = 0;
+  let viewportHeight = 0;
+  let frameHeight = 0;
+  let contentsHeight = 0;
+
+  let oldItems = [];
+  let heightMap = [];
+  let visible: { key: number, index: number, data: any, show: boolean }[] = [];
+  let mounted;
+  let lastStart = 0;
+
+  let top = 0;
+  let bottom = 0;
+
+  const getVisible = (start, end) => {
+    // ;(window as any)._vcOrigConsole.log('getVisible', start, end)
+    const newVisible = []
+    // const visibleCount = end - start
+    const poolCount = visible.length
+    // ;(window as any)._vcOrigConsole.log('poolCount', poolCount)
+
+    if (poolCount === 0) {
+      for (let i = start; i < end; i += 1) {
+        newVisible.push({
+          key: i - start,
+          index: i,
+          data: items[i],
+          show: true,
+        })
+      }
+      return newVisible
+    }
+
+    const firstPool = visible[0].index
+    const lastPool = visible[poolCount - 1].index + 1
+
+    // ;(window as any)._vcOrigConsole.log('firstPool', firstPool)
+    // ;(window as any)._vcOrigConsole.log('lastPool', lastPool)
+
+    // 计算新的 visible 区域
+    const newFirstPool = start <= lastPool
+      // 1. 开头一定在 [0, start]
+      // 2. 开头一定在 [firstPool, lastPool) 之间
+      ? Math.max(0, Math.min(start, Math.max(firstPool, Math.min(lastPool - 1, end - poolCount))))
+      : start // lastPool 如果比 start 小，则前部无法保留下来
+
+    const newLastPool = firstPool <= end
+      // 1. 结尾一定在 [end, items.length] 之间
+      // 2. 结尾一定在 (firstPool, lastPool] 之间
+      ? Math.max(end, Math.min(items.length, Math.max(firstPool + 1, Math.min(lastPool, newFirstPool + poolCount))))
+      : end // end 如果比 firstPool 小，则后部无法保留下来
+
+    // ;(window as any)._vcOrigConsole.log('newFirstPool', newFirstPool)
+    // ;(window as any)._vcOrigConsole.log('newLastPool', newLastPool)
+
+    if (newLastPool - newFirstPool < poolCount) {
+      // 数量少于上次，无法复用，全都重新生成
+      for (let i = start; i < end; i += 1) {
+        newVisible.push({
+          key: i - start,
+          index: i,
+          data: items[i],
+          show: true,
+        })
+      }
+      return newVisible
+    }
+
+    let usedPoolIndex = 0
+    let usedPoolOffset = 0
+
+    // 复用区域
+    let reuseStart = 0
+    let reuseEnd = 0
+
+    if (lastPool < newFirstPool || newLastPool < firstPool) {
+      // 完全没有交集，随便复用
+      reuseStart = newFirstPool
+      reuseEnd = newFirstPool + poolCount
+    } else if (firstPool < newFirstPool) {
+      // 开头复用
+      usedPoolOffset = newFirstPool - firstPool
+      reuseStart = newFirstPool
+      reuseEnd = newFirstPool + poolCount
+    } else if (newLastPool < lastPool) {
+      // 尾部复用
+      usedPoolOffset = poolCount - (lastPool - newLastPool)
+      reuseStart = newLastPool - poolCount
+      reuseEnd = newLastPool
+    } else if (newFirstPool <= firstPool && lastPool <= newLastPool) {
+      // 新的 visible 是完全子集，直接复用
+      reuseStart = firstPool
+      reuseEnd = lastPool
+    }
+
+    // ;(window as any)._vcOrigConsole.log('usedPoolIndex', usedPoolIndex)
+    // ;(window as any)._vcOrigConsole.log('usedPoolOffset', usedPoolOffset)
+    // ;(window as any)._vcOrigConsole.log('reuseStart', reuseStart)
+    // ;(window as any)._vcOrigConsole.log('reuseEnd', reuseEnd)
+
+    // 开头不可见区域
+    // 如果有不可见区域，则一定是来自上一次 visible 的复用 row
+    for (let i = newFirstPool; i < start; i += 1, usedPoolIndex += 1) {
+      const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount]
+      newVisible.push({
+        key: pool.key,
+        index: i,
+        data: items[i],
+        show: false,
+      })
+    }
+
+    // 可见区域
+    for (let i = start, keyIndex = 0; i < end; i += 1) {
+      let key
+      if (reuseStart <= i && i < reuseEnd) {
+        // 复用 row
+        const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount]
+        key = pool.key
+        usedPoolIndex += 1
+      } else {
+        // 新建 row
+        key = poolCount + keyIndex
+        keyIndex += 1
+      }
+      newVisible.push({
+        key,
+        index: i,
+        data: items[i],
+        show: true,
+      })
+    }
+
+    // 末尾不可见区域
+    // 如果有不可见区域，则一定是来自上一次 visible 的复用 row
+    for (let i = end; i < newLastPool; i += 1, usedPoolIndex += 1) {
+      const pool = visible[(usedPoolOffset + usedPoolIndex) % poolCount]
+      newVisible.push({
+        key: pool.key,
+        index: i,
+        data: items[i],
+        show: false,
+      })
+    }
+
+    return newVisible
+  }
+
+  const getScrollExtent = () => Math.max(0, contentsHeight - viewportHeight);
+
+  let isOnBottom = true;
+  let avoidRefresh = false
+
+  const scrollHandler = new ScrollHandler(getScrollExtent, (pos) => {
+    // if (pos < 0) {
+    //   ;(window as any)._vcOrigConsole.error('invalid pos', pos, new Error().stack);
+    //   debugger
+    // }
+    isOnBottom = Math.abs(pos - getScrollExtent()) <= 1;
+
+    // refresh first to avoid recaculating styles caused by changing transform styles below.
+    if (avoidRefresh) {
+      avoidRefresh = false
+    } else {
+      refresh(items, pos, viewportHeight, headerHeight);
+    }
+
+    const transform = `translateY(${-pos}px) translateZ(0)`;
+    contents.style.transform = transform;
+  });
+
+  const scrollToBottom = (force?: boolean) => {
+    const maxScrollHeight = getScrollExtent();
+    if (force || scrollHandler.getPosition() > maxScrollHeight) {
+      scrollHandler.updatePosition(maxScrollHeight);
+    }
+  };
+
+  function initItems(items) {
+    return init(items, viewportHeight, itemHeight, headerHeight);
+  }
+
+  // whenever `items` or `itemHeight` changes, refresh the viewport
+  $: if (mounted) initItems(items);
+
+  function init(items, viewportHeight, itemHeight, headerHeight) {
+    // preserve heightMap
+    const itemsHeightMap = new Map<any, number>();
+    heightMap = [];
+
+    // ;(window as any)._vcOrigConsole.log('init');
+    let reuseHeightCount = 0
+
+    for (let i = 0; i < oldItems.length; i += 1) {
+      itemsHeightMap[oldItems[i]] = heightMap[i];
+    }
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i];
+      if (itemsHeightMap.has(item)) {
+        heightMap.push(itemsHeightMap.get(item));
+        reuseHeightCount += 1
+      } else {
+        heightMap.push(itemHeight);
+      }
+    }
+
+    // ;(window as any)._vcOrigConsole.log('reuseHeightCount', reuseHeightCount);
+    // ;(window as any)._vcOrigConsole.log('new height count', items.length -= reuseHeightCount);
+
+    oldItems = items;
+
+    if (viewportHeight === 0) {
+      // viewport is not visible
+      return refresh([], 0, 0, 0);
+    }
+
+    refresh(
+      items,
+      scrollHandler.getPosition(),
+      viewportHeight,
+      headerHeight
+    );
+
+    scrollToBottom(isOnBottom);
+  }
+
+  let refreshing = false;
+
+  function refresh(
+    items: any[],
+    scrollTop: number,
+    viewportHeight: number,
+    headerHeight: number
+  ) {
+    if (refreshing) return;
+    refreshing = true;
+    // ;(window as any)._vcOrigConsole.log('refresh begin');
+
+    try {
+      let oldStart = start;
+      let oldEnd = end;
+
+      let i = 0;
+      let y = headerHeight;
+
+      while (i < items.length && y + heightMap[i] < scrollTop - buffer) {
+        y += heightMap[i];
+        i += 1;
+      }
+
+      start = i;
+      top = y - headerHeight;
+
+      while (i < items.length && y < scrollTop + viewportHeight + buffer) {
+        y += heightMap[i];
+        i += 1;
+      }
+
+      end = i;
+
+      let newBottom = 0;
+      for (; i < items.length; i += 1) newBottom += heightMap[i];
+      bottom = newBottom;
+
+      if (start === oldStart && end === oldEnd) return;
+
+      visible = getVisible(start, end);
+      lastStart = oldStart
+    } finally {
+      // ;(window as any)._vcOrigConsole.log('refresh complete');
+      refreshing = false;
+    }
+  }
+
+  const registerHeightObserver = (
+    getElem: () => HTMLElement | null,
+    heightUpdater: (height: number) => void
+  ) => {
+    let observer: ResizeObserver | null;
+
+    onMount(() => {
+      const elem = getElem();
+      if (elem) {
+        heightUpdater(elem.getBoundingClientRect().height);
+        if (observer) observer.disconnect();
+        observer = new ResizeObserver((entries) => {
+          const entry = entries[0];
+          heightUpdater(entry.contentRect.height);
+        });
+
+        observer.observe(elem);
+      } else {
+        heightUpdater(0);
+        if (observer) {
+          observer.disconnect();
+          observer = null;
+        }
+      }
+    });
+
+    onDestroy(() => {
+      if (observer) {
+        observer.disconnect();
+        observer = null;
+      }
+    });
+  };
+
+  registerHeightObserver(
+    () => viewport,
+    async (height) => {
+      if (viewportHeight === height) return;
+      // (window as any)._vcOrigConsole.log("viewport height resize", height);
+      // simply refresh is viewport height changes
+      const oldViewportHeight = viewportHeight;
+
+      viewportHeight = height;
+
+      // setTimeout to avoid ResizeObserver loop limit exceeded error
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      if (oldViewportHeight === 0) {
+        // viewport invisible to visible
+        refresh(
+          items,
+          scrollHandler.getPosition(),
+          viewportHeight,
+          headerHeight
+        );
+        scrollToBottom(isOnBottom);
+      } else if (viewportHeight === 0) {
+        // visible to invisible
+        refresh([], 0, 0, 0);
+      } else {
+        scrollToBottom(isOnBottom);
+        refresh(
+          items,
+          scrollHandler.getPosition(),
+          viewportHeight,
+          headerHeight
+        );
+      }
+    }
+  );
+
+  registerHeightObserver(
+    () => header,
+    async (height) => {
+      if (headerHeight === height) return;
+      // (window as any)._vcOrigConsole.log("header height resize", height);
+      // simply refresh is header height changes
+      headerHeight = height;
+
+      // setTimeout to avoid ResizeObserver loop limit exceeded error
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      scrollToBottom();
+      refresh(
+        items,
+        scrollHandler.getPosition(),
+        viewportHeight,
+        headerHeight
+      );
+    }
+  );
+
+  registerHeightObserver(
+    () => footer,
+    (height) => {
+      if (footerHeight === height) return;
+      // ;(window as any)._vcOrigConsole.log('footer height resize', height);
+      // no need to fresh
+      footerHeight = height;
+    }
+  );
+
+  registerHeightObserver(
+    () => contents,
+    (height) => {
+      if (contentsHeight === height) return;
+      contentsHeight = height;
+    }
+  );
+
+  registerHeightObserver(
+    () => frame,
+    async (height) => {
+      if (frameHeight === height) return;
+      // ;(window as any)._vcOrigConsole.log('frame height resize', frameHeight, height);
+      // when item height changes, we need to refresh
+      if (refreshing) return; // refresh process will cause content height change
+
+      frameHeight = height;
+
+      let scrollOffset = 0
+
+      // update row actual height
+      for (let i = 0; i < visible.length; i += 1) {
+        const info = visible[i]
+        if (!info.show) continue
+
+        const row = rows[i];
+        const rowHeight = row?.getBoundingClientRect().height ?? itemHeight;
+        const index = info.index
+        if (index < lastStart) {
+          scrollOffset += rowHeight - heightMap[index]
+        }
+        heightMap[index] = rowHeight;
+        frameHeight += rowHeight;
+      }
+
+      // ;(window as any)._vcOrigConsole.log('frame height refresh');
+      const maxScrollHeight = getScrollExtent();
+      const pos = scrollHandler.getPosition()
+      if (scrollOffset || pos > maxScrollHeight) {
+        // if (scrollOffset) {
+        //   ;(window as any)._vcOrigConsole.log('scrollOffset', scrollOffset);
+        // }
+        avoidRefresh = true
+        scrollHandler.updatePosition(Math.min(maxScrollHeight, pos + scrollOffset));
+      }
+
+      // setTimeout to avoid ResizeObserver loop limit exceeded error
+      await new Promise(resolve => setTimeout(resolve, 0))
+      refresh(items, pos, viewportHeight, headerHeight);
+    }
+  );
+
+  // trigger initial refresh
+  onMount(() => {
+    mounted = true;
+    Style.use();
+  });
+
+  onDestroy(() => {
+    Style.unuse();
+  });
+
+  const touchTracker = new TouchTracker(scrollHandler);
+</script>
+
+<div
+  bind:this={viewport}
+  on:touchstart={touchTracker.handleTouchStart}
+  on:touchmove={touchTracker.handleTouchMove}
+  on:touchend={touchTracker.handleTouchEnd}
+  on:touchcancel={touchTracker.handleTouchCancel}
+  on:wheel={touchTracker.handleWheel}
+  class="vc-scroller-viewport"
+>
+  <div bind:this={contents} class="vc-scroller-contents">
+    {#if $$slots.header}
+      <div bind:this={header} class="vc-scroller-header">
+        <slot name="header" />
+      </div>
+    {/if}
+    <div
+      bind:this={frame}
+      class="vc-scroller-items"
+      style:margin-top="{top}px"
+      style:margin-bottom="{bottom}px"
+    >
+      {#if items.length}
+        {#each visible as row, i (row.key)}
+          <div
+            bind:this={rows[i]}
+            class="vc-scroller-item"
+            style:display={row.show ? "block" : "none"}
+          >
+            <slot name="item" item={row.data}>Missing template</slot>
+          </div>
+        {/each}
+      {:else}
+        <slot name="empty" />
+      {/if}
+    </div>
+    {#if $$slots.footer}
+      <div bind:this={footer} class="vc-scroller-footer">
+        <slot name="footer" />
+      </div>
+    {/if}
+  </div>
+</div>

--- a/src/component/recycleScroller/scroll/friction.ts
+++ b/src/component/recycleScroller/scroll/friction.ts
@@ -1,0 +1,43 @@
+/** *
+ * Friction physics simulation. Friction is actually just a simple
+ * power curve; the only trick is taking the natural log of the
+ * initial drag so that we can express the answer in terms of time.
+ */
+class Friction {
+  private _drag: number;
+  private _dragLog: number;
+  private _x = 0;
+  private _v = 0;
+  private _startTime = 0;
+
+  constructor(drag: number) {
+    this._drag = drag;
+    this._dragLog = Math.log(drag);
+  }
+
+  set(x: number, v: number, t?: number) {
+    this._x = x;
+    this._v = v;
+    this._startTime = t || Date.now();
+  }
+
+  x(t: number) {
+    const dt = (t - this._startTime) / 1000.0;
+    return (
+      this._x +
+      (this._v * Math.pow(this._drag, dt)) / this._dragLog -
+      this._v / this._dragLog
+    );
+  }
+
+  dx(t: number) {
+    const dt = (t - this._startTime) / 1000.0;
+    return this._v * Math.pow(this._drag, dt);
+  }
+
+  done(t: number) {
+    return Math.abs(this.dx(t)) < 3;
+  }
+}
+
+export default Friction;

--- a/src/component/recycleScroller/scroll/linear.ts
+++ b/src/component/recycleScroller/scroll/linear.ts
@@ -1,0 +1,32 @@
+class Linear {
+  private _x = 0;
+  private _endX = 0;
+  private _v = 0;
+  private _startTime = 0;
+  private _endTime = 0;
+
+  set(x: number, endX: number, dt: number, t?: number) {
+    this._x = x;
+    this._endX = endX;
+    this._v = (endX - x) / dt;
+    this._startTime = t || Date.now()
+    this._endTime = this._startTime + dt;
+  }
+
+  x(t: number) {
+    if (this.done(t)) return this._endX;
+    const dt = t - this._startTime;
+    return this._x + this._v * dt;
+  }
+
+  dx(t: number) {
+    if (this.done(t)) return 0;
+    return this._v
+  }
+
+  done(t: number) {
+    return t >= this._endTime;
+  }
+}
+
+export default Linear;

--- a/src/component/recycleScroller/scroll/scroll.ts
+++ b/src/component/recycleScroller/scroll/scroll.ts
@@ -1,0 +1,86 @@
+import Friction from "./friction";
+import Spring from "./spring";
+
+/** *
+ * Scroll combines Friction and Spring to provide the
+ * classic "flick-with-bounce" behavior.
+ */
+class Scroll {
+  private _getExtend: () => number;
+  private _friction = new Friction(0.05);
+  private _spring = new Spring(1, 90, 20);
+  private _toEdge = false;
+
+  constructor(getExtend: () => number, private _enableSpring: boolean) {
+    this._getExtend = getExtend;
+  }
+
+  set(x: number, v: number, t?: number) {
+    if (t === undefined) t = Date.now();
+    this._friction.set(x, v, t);
+
+    // If we're over the extent or zero then start springing. Notice that we also consult
+    // velocity because we don't want flicks that start in the overscroll to get consumed
+    // by the spring.
+    if (x > 0 && v >= 0) {
+      this._toEdge = true;
+      if (this._enableSpring) {
+        this._spring.set(0, x, v, t);
+      }
+    } else {
+      const extent = this._getExtend();
+      if (x < -extent && v <= 0) {
+        this._toEdge = true;
+        if (this._enableSpring) {
+          this._spring.set(-extent, x, v, t);
+        }
+      } else {
+        this._toEdge = false;
+      }
+    }
+  }
+
+  x(t: number) {
+    // We've entered the spring, use the value from there.
+    if (this._enableSpring && this._toEdge) {
+      return this._spring.x(t);
+    }
+    // We're still in friction.
+    const x = this._friction.x(t);
+    const dx = this._friction.dx(t);
+    // If we've gone over the edge the roll the momentum into the spring.
+    if (x > 0 && dx >= 0) {
+      this._toEdge = true;
+      if (this._enableSpring) {
+        this._spring.set(0, x, dx, t);
+      } else {
+        return 0
+      }
+    } else {
+      const extent = this._getExtend();
+      if (x < -extent && dx <= 0) {
+        this._toEdge = true;
+        if (this._enableSpring) {
+          this._spring.set(-extent, x, dx, t);
+        } else {
+          return -extent
+        }
+      }
+    }
+    return x;
+  }
+
+  dx(t: number) {
+    if (!this._toEdge) return this._friction.dx(t);
+    if (this._enableSpring) return this._spring.dx(t);
+    return 0
+  }
+
+  done(t: number) {
+    if (!this._toEdge) return this._friction.done(t);
+    if (this._enableSpring) return this._spring.done(t);
+    return true
+  }
+}
+
+export default Scroll;

--- a/src/component/recycleScroller/scroll/scrollHandler.ts
+++ b/src/component/recycleScroller/scroll/scrollHandler.ts
@@ -1,0 +1,174 @@
+import Scroll from "./scroll";
+import { TrackerHandler } from "./touchTracker";
+
+// This function sets up a requestAnimationFrame-based timer which calls
+// the callback every frame while the physics model is still moving.
+// It returns a function that may be called to cancel the animation.
+function animation(
+  physicsModel: { done: (t: number) => boolean },
+  callback: (t: number) => void
+) {
+  let id: ReturnType<typeof requestAnimationFrame>;
+  let cancelled: boolean;
+
+  const onFrame = () => {
+    if (cancelled) return;
+    const t = Date.now();
+    callback(t);
+    if (physicsModel.done(t)) return;
+    id = requestAnimationFrame(onFrame);
+  };
+
+  const cancel = () => {
+    cancelAnimationFrame(id);
+    cancelled = true;
+  };
+
+  onFrame();
+
+  return { cancel };
+}
+
+const UNDERSCROLL_TRACKING = 0;
+
+class ScrollHandler implements TrackerHandler {
+  private _scroll: Scroll;
+  private _startPosition = 0;
+  private _position = 0;
+  private _animate: ReturnType<typeof animation> | null = null;
+  private _getExtent: () => number;
+
+  constructor(
+    getExtent: () => number,
+    private _updatePosition: (pos: number) => void
+  ) {
+    this._getExtent = getExtent;
+    this._scroll = new Scroll(getExtent, false);
+  }
+
+  onTouchStart() {
+    let pos = this._position;
+
+    if (pos > 0) {
+      pos *= UNDERSCROLL_TRACKING;
+    } else {
+      const extent = this._getExtent();
+      if (pos < -extent) {
+        pos = (pos + extent) * UNDERSCROLL_TRACKING - extent;
+      }
+    }
+
+    this._startPosition = this._position = pos;
+
+    if (this._animate) {
+      this._animate.cancel();
+      this._animate = null;
+    }
+
+    this._updatePosition(-pos);
+  }
+
+  onTouchMove(dx: number, dy: number) {
+    let pos = dy + this._startPosition;
+
+    if (pos > 0) {
+      pos *= UNDERSCROLL_TRACKING;
+    } else {
+      const extent = this._getExtent();
+      if (pos < -extent) {
+        pos = (pos + extent) * UNDERSCROLL_TRACKING - extent;
+      }
+    }
+
+    this._position = pos;
+
+    this._updatePosition(-pos);
+  }
+
+  onTouchEnd(dx: number, dy: number, velocityX: number, velocityY: number) {
+    let pos = dy + this._startPosition;
+
+    if (pos > 0) {
+      pos *= UNDERSCROLL_TRACKING;
+    } else {
+      const extent = this._getExtent();
+      if (pos < -extent) {
+        pos = (pos + extent) * UNDERSCROLL_TRACKING - extent;
+      }
+    }
+    this._position = pos;
+    this._updatePosition(-pos);
+    if (Math.abs(dy) <= 0.1 && Math.abs(velocityY) <= 0.1) return
+    const scroll = this._scroll;
+    scroll.set(pos, velocityY);
+    this._animate = animation(scroll, (t) => {
+      const pos = (this._position = scroll.x(t));
+      this._updatePosition(-pos);
+    });
+  }
+
+  onTouchCancel(): void {
+    let pos = this._position;
+
+    if (pos > 0) {
+      pos *= UNDERSCROLL_TRACKING;
+    } else {
+      const extent = this._getExtent();
+      if (pos < -extent) {
+        pos = (pos + extent) * UNDERSCROLL_TRACKING - extent;
+      }
+    }
+
+    this._position = pos;
+    const scroll = this._scroll;
+    scroll.set(pos, 0);
+    this._animate = animation(scroll, (t) => {
+      const pos = (this._position = scroll.x(t));
+      this._updatePosition(-pos);
+    });
+  }
+
+  onWheel(x: number, y: number): void {
+    let pos = this._position - y;
+
+    if (this._animate) {
+      this._animate.cancel();
+      this._animate = null;
+    }
+
+    if (pos > 0) {
+      pos = 0;
+    } else {
+      const extent = this._getExtent();
+      if (pos < -extent) {
+        pos = -extent;
+      }
+    }
+
+    this._position = pos
+
+    this._updatePosition(-pos)
+  }
+
+  getPosition() {
+    return -this._position;
+  }
+
+  updatePosition(position) {
+    const dx = -position - this._position;
+    this._startPosition += dx;
+    this._position += dx
+    const pos = this._position;
+
+    this._updatePosition(-pos);
+
+    const scroll = this._scroll;
+    const t = Date.now();
+    if (!scroll.done(t)) {
+      const dx = scroll.dx(t);
+      scroll.set(pos, dx, t);
+    }
+  }
+}
+
+export default ScrollHandler;

--- a/src/component/recycleScroller/scroll/spring.ts
+++ b/src/component/recycleScroller/scroll/spring.ts
@@ -1,0 +1,132 @@
+const epsilon = 0.1;
+const almostEqual = (a: number, b: number) =>
+  a > b - epsilon && a < b + epsilon;
+const almostZero = (a: number) => almostEqual(a, 0);
+
+/***
+ * Simple Spring implementation -- this implements a damped spring using a symbolic integration
+ * of Hooke's law: F = -kx - cv. This solution is significantly more performant and less code than
+ * a numerical approach such as Facebook Rebound which uses RK4.
+ *
+ * This physics textbook explains the model:
+ *  http://www.stewartcalculus.com/data/CALCULUS%20Concepts%20and%20Contexts/upfiles/3c3-AppsOf2ndOrders_Stu.pdf
+ *
+ * A critically damped spring has: damping*damping - 4 * mass * springConstant == 0. If it's greater than zero
+ * then the spring is overdamped, if it's less than zero then it's underdamped.
+ */
+const getSolver = (
+  mass: number,
+  springConstant: number,
+  damping: number
+): ((
+  initial: number,
+  velocity: number
+) => { x: (t: number) => number; dx: (t: number) => number }) => {
+  const c = damping;
+  const m = mass;
+  const k = springConstant;
+  const cmk = c * c - 4 * m * k;
+  if (cmk == 0) {
+    // The spring is critically damped.
+    // x = (c1 + c2*t) * e ^(-c/2m)*t
+    const r = -c / (2 * m);
+    return (initial, velocity) => {
+      const c1 = initial;
+      const c2 = velocity / (r * initial);
+      return {
+        x: (dt) => (c1 + c2 * dt) * Math.pow(Math.E, r * dt),
+        dx: (dt) => (r * (c1 + c2 * dt) + c2) * Math.pow(Math.E, r * dt),
+      };
+    };
+  } else if (cmk > 0) {
+    // The spring is overdamped; no bounces.
+    // x = c1*e^(r1*t) + c2*e^(r2t)
+    // Need to find r1 and r2, the roots, then solve c1 and c2.
+    const r1 = (-c - Math.sqrt(cmk)) / (2 * m);
+    const r2 = (-c + Math.sqrt(cmk)) / (2 * m);
+    return (initial, velocity) => {
+      const c2 = (velocity - r1 * initial) / (r2 - r1);
+      const c1 = initial - c2;
+
+      return {
+        x: (dt) => c1 * Math.pow(Math.E, r1 * dt) + c2 * Math.pow(Math.E, r2 * dt),
+        dx: (dt) =>
+          c1 * r1 * Math.pow(Math.E, r1 * dt) +
+          c2 * r2 * Math.pow(Math.E, r2 * dt),
+      };
+    };
+  } else {
+    // The spring is underdamped, it has imaginary roots.
+    // r = -(c / 2*m) +- w*i
+    // w = sqrt(4mk - c^2) / 2m
+    // x = (e^-(c/2m)t) * (c1 * cos(wt) + c2 * sin(wt))
+    const w = Math.sqrt(4 * m * k - c * c) / (2 * m);
+    const r = -((c / 2) * m);
+    return (initial, velocity) => {
+      const c1 = initial;
+      const c2 = (velocity - r * initial) / w;
+
+      return {
+        x: (dt) =>
+          Math.pow(Math.E, r * dt) *
+          (c1 * Math.cos(w * dt) + c2 * Math.sin(w * dt)),
+        dx: (dt) => {
+          const power = Math.pow(Math.E, r * dt);
+          const cos = Math.cos(w * dt);
+          const sin = Math.sin(w * dt);
+          return (
+            power * (c2 * w * cos - c1 * w * sin) +
+            r * power * (c2 * sin + c1 * cos)
+          );
+        },
+      };
+    };
+  }
+};
+
+class Spring {
+
+  private _solver: (
+    initial: number,
+    velocity: number
+  ) => {
+    x: (dt: number) => number;
+    dx: (dt: number) => number;
+  };
+  private _solution: {
+    x: (dt: number) => number;
+    dx: (dt: number) => number;
+  } | null
+  private _endPosition: number;
+  private _startTime: number;
+
+  constructor(mass: number, springConstant: number, damping: number) {
+    this._solver = getSolver(mass, springConstant, damping);
+    this._solution = null
+    this._endPosition = 0;
+    this._startTime = 0;
+  }
+  x(t: number) {
+    if (!this._solution) return 0
+    const dt = (t - this._startTime) / 1000.0;
+    return this._endPosition + this._solution.x(dt);
+  }
+  dx(t: number) {
+    if (!this._solution) return 0
+    const dt = (t - this._startTime) / 1000.0;
+    return this._solution.dx(dt);
+  }
+  set(endPosition: number, x: number, velocity: number, t?: number) {
+    if (!t) t = Date.now();
+    this._endPosition = endPosition
+    if (x == endPosition && almostZero(velocity)) return;
+    this._solution = this._solver(x - endPosition, velocity)
+    this._startTime = t
+  }
+  done(t: number) {
+    if (!t) t = Date.now();
+    return almostEqual(this.x(t), this._endPosition) && almostZero(this.dx(t));
+  }
+}
+
+export default Spring;

--- a/src/component/recycleScroller/scroll/touchTracker.ts
+++ b/src/component/recycleScroller/scroll/touchTracker.ts
@@ -63,6 +63,7 @@ class TouchTracker {
         };
       }
     }
+    return null
   }
 
   private _onTouchMove = throttleRAF(() => {

--- a/src/component/recycleScroller/scroll/touchTracker.ts
+++ b/src/component/recycleScroller/scroll/touchTracker.ts
@@ -1,0 +1,165 @@
+export interface TrackerHandler {
+  onTouchStart(): void;
+  onTouchMove(x: number, y: number): void;
+  onTouchEnd(x: number, y: number, velocityX: number, velocityY: number): void;
+  onTouchCancel(): void;
+  onWheel(x: number, y: number): void;
+}
+
+const throttleRAF = (fn: () => void) => {
+  let timer: ReturnType<typeof requestAnimationFrame> | null = null
+  let call = false
+
+  const notify = () => {
+    call = false
+    fn()
+    timer = requestAnimationFrame(() => {
+      timer = null
+      if (call) notify()
+    })
+  }
+
+  const trigger = () => {
+    if (timer === null) {
+      notify()
+    } else {
+      call = true
+    }
+  }
+
+  const cancel = () => {
+    if (timer) {
+      cancelAnimationFrame(timer)
+      call = false
+      timer = null
+    }
+  }
+
+  return {
+    trigger,
+    cancel,
+  }
+}
+
+class TouchTracker {
+  private _touchId: number | null = null;
+  private _startX = 0;
+  private _startY = 0;
+  private _historyX: number[] = [];
+  private _historyY: number[] = [];
+  private _historyTime: number[] = [];
+  private _wheelDeltaX = 0;
+  private _wheelDeltaY = 0;
+
+  constructor(private _handler: TrackerHandler) {}
+
+  private _getTouchDelta(e: TouchEvent): { x: number; y: number } | null {
+    if (this._touchId === null) return null;
+    for (const touch of e.changedTouches) {
+      if (touch.identifier === this._touchId) {
+        return {
+          x: touch.pageX - this._startX,
+          y: touch.pageY - this._startY,
+        };
+      }
+    }
+  }
+
+  private _onTouchMove = throttleRAF(() => {
+    const deltaX = this._historyX[this._historyX.length - 1]
+    const deltaY = this._historyY[this._historyY.length - 1]
+    this._handler.onTouchMove(deltaX, deltaY);
+  })
+
+  private _onWheel = throttleRAF(() => {
+    const deltaX = this._wheelDeltaX
+    const deltaY = this._wheelDeltaY
+
+    this._wheelDeltaX = 0
+    this._wheelDeltaY = 0
+
+    this._handler.onWheel(deltaX, deltaY);
+  })
+
+  handleTouchStart = (e: TouchEvent) => {
+    e.preventDefault();
+
+    const touch = e.touches[0];
+    this._touchId = touch.identifier;
+    this._startX = touch.pageX;
+    this._startY = touch.pageY;
+    this._historyX = [0];
+    this._historyY = [0];
+    this._historyTime = [Date.now()];
+
+    this._handler.onTouchStart();
+  };
+
+  handleTouchMove = (e: TouchEvent) => {
+    e.preventDefault();
+
+    const delta = this._getTouchDelta(e);
+    if (delta === null) return;
+
+    this._historyX.push(delta.x);
+    this._historyY.push(delta.y);
+    this._historyTime.push(Date.now());
+
+    this._onTouchMove.trigger()
+  };
+
+  handleTouchEnd = (e: TouchEvent) => {
+    e.preventDefault();
+
+    const delta = this._getTouchDelta(e);
+    if (delta === null) return;
+
+    this._onTouchMove.cancel()
+
+    let velocityX = 0;
+    let velocityY = 0;
+    const lastTime = Date.now();
+    const lastY = delta.y;
+    const lastX = delta.x;
+    const historyTime = this._historyTime;
+    for (let i = historyTime.length - 1; i > 0; i -= 1) {
+      const t = historyTime[i];
+      const dt = lastTime - t;
+      if (dt > 30) {
+        velocityX = ((lastX - this._historyX[i]) * 1000) / dt;
+        velocityY = ((lastY - this._historyY[i]) * 1000) / dt;
+        break;
+      }
+    }
+
+    this._touchId = null;
+
+    // ;(window as any)._vcOrigConsole.log('onTouchEnd', delta, velocityX, velocityY);
+    this._handler.onTouchEnd(delta.x, delta.y, velocityX, velocityY);
+  };
+
+  handleTouchCancel = (e: TouchEvent) => {
+    e.preventDefault();
+
+    const delta = this._getTouchDelta(e);
+    if (delta === null) return;
+
+    this._onTouchMove.cancel()
+
+    this._touchId = null;
+
+    // ;(window as any)._vcOrigConsole.log('onTouchCancel');
+    this._handler.onTouchCancel();
+  };
+
+  handleWheel = (e: WheelEvent) => {
+    e.preventDefault();
+
+    this._wheelDeltaX += e.deltaX
+    this._wheelDeltaY += e.deltaY
+
+    this._onWheel.trigger()
+  };
+}
+
+export default TouchTracker;

--- a/src/component/recycleScroller/scroll/touchTracker.ts
+++ b/src/component/recycleScroller/scroll/touchTracker.ts
@@ -66,11 +66,11 @@ class TouchTracker {
     return null
   }
 
-  private _onTouchMove = throttleRAF(() => {
+  private _onTouchMove = () => {
     const deltaX = this._historyX[this._historyX.length - 1]
     const deltaY = this._historyY[this._historyY.length - 1]
     this._handler.onTouchMove(deltaX, deltaY);
-  })
+  }
 
   private _onWheel = throttleRAF(() => {
     const deltaX = this._wheelDeltaX
@@ -106,7 +106,7 @@ class TouchTracker {
     this._historyY.push(delta.y);
     this._historyTime.push(Date.now());
 
-    this._onTouchMove.trigger()
+    this._onTouchMove()
   };
 
   handleTouchEnd = (e: TouchEvent) => {
@@ -114,8 +114,6 @@ class TouchTracker {
 
     const delta = this._getTouchDelta(e);
     if (delta === null) return;
-
-    this._onTouchMove.cancel()
 
     let velocityX = 0;
     let velocityY = 0;
@@ -144,8 +142,6 @@ class TouchTracker {
 
     const delta = this._getTouchDelta(e);
     if (delta === null) return;
-
-    this._onTouchMove.cancel()
 
     this._touchId = null;
 

--- a/src/core/core.svelte
+++ b/src/core/core.svelte
@@ -4,7 +4,7 @@
   import { default as SwitchButton } from './switchButton.svelte';
   import { contentStore } from './core.model';
   import Style from './core.less';
-  import type { IVConsoleTopbarOptions, IVConsoleToolbarOptions } from '../lib/plugin';
+  import type { IVConsoleTopbarOptions, IVConsoleToolbarOptions, IVConsoleTabOptions } from '../lib/plugin';
 
   /*************************************
    * Public properties
@@ -14,6 +14,7 @@
     id: string;
     name: string;
     hasTabPanel: boolean;
+    tabOptions?: IVConsoleTabOptions;
     topbarList?: IVConsoleTopbarOptions[];
     toolbarList?: IVConsoleToolbarOptions[];
   }
@@ -345,6 +346,7 @@
         <div
           id="__vc_plug_{plugin.id}"
           class="vc-plugin-box"
+          class:vc-fixed-height="{plugin.tabOptions?.fixedHeight}"
           class:vc-actived="{plugin.id === activedPluginId}"
         ></div>
       {/each}

--- a/src/core/core.ts
+++ b/src/core/core.ts
@@ -290,6 +290,7 @@ export class VConsole {
       id: plugin.id,
       name: plugin.name,
       hasTabPanel: false,
+      tabOptions: undefined,
       topbarList: [],
       toolbarList: [],
     };
@@ -297,14 +298,16 @@ export class VConsole {
     // start init
     plugin.trigger('init');
     // render tab (if it is a tab plugin then it should has tab-related events)
-    plugin.trigger('renderTab', (tabboxHTML) => {
+    plugin.trigger('renderTab', (tabboxHTML, options = {}) => {
       // render tabbar
-      this.compInstance.pluginList[plugin.id].hasTabPanel = true;
+      const pluginInfo = this.compInstance.pluginList[plugin.id]
+      pluginInfo.hasTabPanel = true;
+      pluginInfo.tabOptions = options;
       // render tabbox
       if (!!tabboxHTML) {
         // when built-in plugins are initializing in the same time,
         // plugin's `.vc-plugin-box` element will be re-order by `pluginOrder` option,
-        // so the innerHTML should be inserted with a delay 
+        // so the innerHTML should be inserted with a delay
         // to make sure getting the right `.vc-plugin-box`. (issue #559)
         setTimeout(() => {
           const divContentInner = document.querySelector('#__vc_plug_' + plugin.id);

--- a/src/core/style/view.less
+++ b/src/core/style/view.less
@@ -57,9 +57,8 @@
 // content
 .vc-content {
   background-color: var(--VC-BG-2);
-  overflow: hidden;
-  // overflow-x: hidden;
-  // overflow-y: auto;
+  overflow-x: hidden;
+  overflow-y: auto;
   position: absolute;
   top: (40em / @font);
   left: 0;
@@ -75,6 +74,8 @@
 .vc-plugin-box {
   display: none;
   position: relative;
+}
+.vc-plugin-box.vc-fixed-height {
   height: 100%;
 }
 .vc-plugin-box.vc-actived {

--- a/src/core/style/view.less
+++ b/src/core/style/view.less
@@ -84,6 +84,7 @@
   display: flex;
   width: 100%;
   height: 100%;
+  overflow-y: auto;
   flex-direction: column;
   -webkit-tap-highlight-color: transparent;
 }

--- a/src/core/style/view.less
+++ b/src/core/style/view.less
@@ -57,8 +57,9 @@
 // content
 .vc-content {
   background-color: var(--VC-BG-2);
-  overflow-x: hidden;
-  overflow-y: auto;
+  overflow: hidden;
+  // overflow-x: hidden;
+  // overflow-y: auto;
   position: absolute;
   top: (40em / @font);
   left: 0;
@@ -74,16 +75,18 @@
 .vc-plugin-box {
   display: none;
   position: relative;
-  min-height: 100%;
+  height: 100%;
 }
 .vc-plugin-box.vc-actived {
   display: block;
 }
 .vc-plugin-content {
-  padding-bottom: (39em / @font) * 2;
+  display: flex;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
   -webkit-tap-highlight-color: transparent;
 }
-.vc-plugin-empty:before,
 .vc-plugin-content:empty:before {
   content: "Empty";
   color: var(--VC-FG-1);
@@ -96,6 +99,16 @@
   text-align: center;
 }
 
+.vc-plugin-empty {
+  color: var(--VC-FG-1);
+  font-size: (15em / @font);
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  justify-content: center
+}
 
 
 // safe area

--- a/src/lib/plugin.ts
+++ b/src/lib/plugin.ts
@@ -30,6 +30,10 @@ export interface IVConsoleToolbarOptions {
   onClick?: (e: Event, data?: any) => any;
 }
 
+export interface IVConsoleTabOptions {
+  fixedHeight?: boolean
+}
+
 /**
  * vConsole Plugin Base Class
  */
@@ -40,7 +44,7 @@ export class VConsolePlugin {
   protected _id: string;
   protected _name: string;
   protected _vConsole: VConsole;
-  
+
   constructor(...args);
   constructor(id: string, name = 'newPlugin') {
     this.id = id;

--- a/src/lib/sveltePlugin.ts
+++ b/src/lib/sveltePlugin.ts
@@ -23,12 +23,12 @@ export class VConsoleSveltePlugin<T extends {} = {}> extends VConsolePlugin {
 
   onRenderTab(callback) {
     const $container = document.createElement('div');
-    this.compInstance = new this.CompClass({
+    const compInstance = this.compInstance = new this.CompClass({
       target: $container,
       props: this.initialProps,
     });
     // console.log('onRenderTab', this.compInstance);
-    callback($container.firstElementChild);
+    callback($container.firstElementChild, compInstance.options);
   }
 
   onRemove() {

--- a/src/log/log.less
+++ b/src/log/log.less
@@ -1,5 +1,5 @@
 @import "../styles/var.less";
 
 .vc-logs-has-cmd {
-  padding-bottom: (80em / @font);
+  // padding-bottom: (80em / @font);
 }

--- a/src/log/log.model.ts
+++ b/src/log/log.model.ts
@@ -21,6 +21,7 @@ export interface IVConsoleLog {
   type: IConsoleLogMethod;
   cmdType?: 'input' | 'output';
   repeated?: number;
+  toggle: Record<string, boolean>;
   date: number;
   data: IVConsoleLogData[]; // the `args: any[]` of `console.log(...args)`
 }
@@ -240,6 +241,7 @@ export class VConsoleLogModel extends VConsoleModel {
       _id: tool.getUniqueID(),
       type: item.type,
       cmdType: opt?.cmdType,
+      toggle: {},
       date: Date.now(),
       data: getLogDatasWithFormatting(item.origData || []),
     };

--- a/src/log/log.model.ts
+++ b/src/log/log.model.ts
@@ -20,7 +20,7 @@ export interface IVConsoleLog {
   _id: string;
   type: IConsoleLogMethod;
   cmdType?: 'input' | 'output';
-  repeated?: number;
+  repeated: number;
   toggle: Record<string, boolean>;
   date: number;
   data: IVConsoleLogData[]; // the `args: any[]` of `console.log(...args)`
@@ -244,6 +244,7 @@ export class VConsoleLogModel extends VConsoleModel {
       toggle: {},
       date: Date.now(),
       data: getLogDatasWithFormatting(item.origData || []),
+      repeated: 0,
     };
     // for (let i = 0; i < item?.origData.length; i++) {
     //   const data: IVConsoleLogData = {

--- a/src/log/log.svelte
+++ b/src/log/log.svelte
@@ -52,11 +52,11 @@
   };
 
   export const scrollToTop = () => {
-    scrollerHandler.scrollTo(0, 500);
+    scrollerHandler.scrollTo(0);
   };
 
   export const scrollToBottom = () => {
-    scrollerHandler.scrollTo(logList.length - 1, 500);
+    scrollerHandler.scrollTo(logList.length - 1);
   };
 
   export const options: IVConsoleTabOptions = {

--- a/src/log/log.svelte
+++ b/src/log/log.svelte
@@ -1,22 +1,23 @@
 <script lang="ts">
-  import { onMount, onDestroy } from 'svelte';
-  import { isMatchedFilterText } from './logTool';
-  import { VConsoleLogStore as Store } from './log.store';
-  import LogRow from './logRow.svelte';
-  import LogCommand from './logCommand.svelte';
-  import Style from './log.less';
-  import type { IConsoleLogMethod, IVConsoleLog } from './log.model';
-  import RecycleScroller from '../component/recycleScroller/recycleScroller.svelte';
+  import { onMount, onDestroy } from "svelte";
+  import { isMatchedFilterText } from "./logTool";
+  import { VConsoleLogStore as Store } from "./log.store";
+  import LogRow from "./logRow.svelte";
+  import LogCommand from "./logCommand.svelte";
+  import Style from "./log.less";
+  import type { IConsoleLogMethod, IVConsoleLog } from "./log.model";
+  import RecycleScroller from "../component/recycleScroller/recycleScroller.svelte";
+  import type { IVConsoleTabOptions } from "../lib/plugin";
 
-  export let pluginId: string = 'default';
+  export let pluginId: string = "default";
   export let showCmd: boolean = false;
-  export let filterType: 'all' | IConsoleLogMethod = 'all';
+  export let filterType: "all" | IConsoleLogMethod = "all";
   export let showTimestamps: boolean = false;
 
   let isInited: boolean = false;
-  let filterText: string = '';
+  let filterText: string = "";
   let store: ReturnType<typeof Store.get>;
-  let scrollerHandler
+  let scrollerHandler;
 
   $: {
     if (!isInited) {
@@ -26,16 +27,16 @@
     }
   }
 
-  let logList: IVConsoleLog[] = []
+  let logList: IVConsoleLog[] = [];
 
   $: {
-    logList = $store.logList.filter(log =>
-      // filterType
-      (filterType === 'all' || filterType === log.type)
-      &&
-      // filterText
-      (filterText === '' || isMatchedFilterText(log, filterText))
-    )
+    logList = $store.logList.filter(
+      (log) =>
+        // filterType
+        (filterType === "all" || filterType === log.type) &&
+        // filterText
+        (filterText === "" || isMatchedFilterText(log, filterText))
+    );
   }
 
   onMount(() => {
@@ -47,16 +48,20 @@
   });
 
   const onFilterText = (e) => {
-    filterText = e.detail.filterText || '';
+    filterText = e.detail.filterText || "";
   };
 
   export const scrollToTop = () => {
-    scrollerHandler.scrollTo(0, 500)
-  }
+    scrollerHandler.scrollTo(0, 500);
+  };
 
   export const scrollToBottom = () => {
-    scrollerHandler.scrollTo(logList.length - 1, 500)
-  }
+    scrollerHandler.scrollTo(logList.length - 1, 500);
+  };
+
+  export const options: IVConsoleTabOptions = {
+    fixedHeight: true,
+  };
 </script>
 
 <div class="vc-plugin-content" class:vc-logs-has-cmd={showCmd}>

--- a/src/log/log.svelte
+++ b/src/log/log.svelte
@@ -16,6 +16,7 @@
   let isInited: boolean = false;
   let filterText: string = '';
   let store: ReturnType<typeof Store.get>;
+  let scrollerHandler
 
   $: {
     if (!isInited) {
@@ -48,10 +49,18 @@
   const onFilterText = (e) => {
     filterText = e.detail.filterText || '';
   };
+
+  export const scrollToTop = () => {
+    scrollerHandler.scrollTo(0, 500)
+  }
+
+  export const scrollToBottom = () => {
+    scrollerHandler.scrollTo(logList.length - 1, 500)
+  }
 </script>
 
 <div class="vc-plugin-content" class:vc-logs-has-cmd={showCmd}>
-  <RecycleScroller items={logList} itemHeight={30} buffer={100} >
+  <RecycleScroller items={logList} itemHeight={30} buffer={100} stickToBottom bind:handler={scrollerHandler}>
     <div slot="empty" class="vc-plugin-empty">Empty</div>
     <LogRow slot="item" let:item={log} log={log} showTimestamps={showTimestamps} />
     <svelte:fragment slot="footer">

--- a/src/log/log.svelte
+++ b/src/log/log.svelte
@@ -60,7 +60,15 @@
 </script>
 
 <div class="vc-plugin-content" class:vc-logs-has-cmd={showCmd}>
-  <RecycleScroller items={logList} itemHeight={30} buffer={100} stickToBottom bind:handler={scrollerHandler}>
+  <RecycleScroller
+    items={logList}
+    itemKey="_id"
+    itemHeight={30}
+    buffer={100}
+    stickToBottom
+    scrollbar
+    bind:handler={scrollerHandler}
+  >
     <div slot="empty" class="vc-plugin-empty">Empty</div>
     <LogRow slot="item" let:item={log} log={log} showTimestamps={showTimestamps} />
     <svelte:fragment slot="footer">

--- a/src/log/log.ts
+++ b/src/log/log.ts
@@ -61,6 +61,18 @@ export class VConsoleLogPlugin extends VConsoleSveltePlugin {
         this.model.clearPluginLog(this.id);
         this.vConsole.triggerEvent('clearLog');
       }
+    }, {
+      name: 'Top',
+      global: false,
+      onClick: (e) => {
+        this.compInstance.scrollToTop()
+      }
+    }, {
+      name: 'Bottom',
+      global: false,
+      onClick: (e) => {
+        this.compInstance.scrollToBottom()
+      }
     }];
     callback(toolList);
   }

--- a/src/log/logCommand.less
+++ b/src/log/logCommand.less
@@ -2,13 +2,10 @@
 
 // container
 .vc-cmd {
-  position: absolute;
   height: (40em / @font);
-  left: 0;
-  right: 0;
-  bottom: (40em / @font);
   border-top: 1px solid var(--VC-FG-3);
-  display: block !important;
+  display: flex;
+  flex-direction: row;
 
   &.vc-filter{
     bottom: 0;
@@ -19,9 +16,10 @@
 .vc-cmd-input-wrap {
   display: flex;
   align-items: center;
+  flex: 1;
   position: relative;
   height: (28em / @font);
-  margin-right: (40em / @font);
+  // margin-right: (40em / @font);
   padding: (6em / @font) (8em / @font);
 }
 .vc-cmd-input {
@@ -40,10 +38,10 @@
 
 // button
 .vc-cmd-btn {
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
+  // position: absolute;
+  // top: 0;
+  // right: 0;
+  // bottom: 0;
   width: (40em / @font);
   border: none;
   background-color: var(--VC-BG-0);

--- a/src/log/logCommand.svelte
+++ b/src/log/logCommand.svelte
@@ -43,7 +43,7 @@
   onDestroy(() => {
     Style.unuse();
   });
-  
+
 
   /*************************************
    * Methods
@@ -109,7 +109,7 @@
           if (promptedList.length >= 100) {
             break;
           }
-          
+
           const key = String(cachedObjKeys[objName][i]);
           const keyPattern = new RegExp('^' + keyName, 'i'); // polyfill String.startsWith
           if (keyPattern.test(key)) {
@@ -222,8 +222,6 @@
 </script>
 
 <form class="vc-cmd" on:submit|preventDefault={onCmdSubmit}>
-  <button class="vc-cmd-btn" type="submit">OK</button>
-
   <ul class='vc-cmd-prompted' style="{promptedStyle}">
     {#if promptedList.length > 0}
       <li class="vc-cmd-prompted-hide" on:click={clearPromptedList}>Close</li>
@@ -252,10 +250,11 @@
     </div>
   {/if}
   </div>
+
+  <button class="vc-cmd-btn" type="submit">OK</button>
 </form>
 
 <form class="vc-cmd vc-filter" on:submit|preventDefault={onFilterSubmit}>
-  <button class="vc-cmd-btn" type="submit">Filter</button>
   <ul class='vc-cmd-prompted'></ul>
   <div class="vc-cmd-input-wrap">
     <textarea
@@ -269,4 +268,5 @@
     </div>
   {/if}
   </div>
+  <button class="vc-cmd-btn" type="submit">Filter</button>
 </form>

--- a/src/log/logRow.svelte
+++ b/src/log/logRow.svelte
@@ -12,7 +12,6 @@
   export let log: IVConsoleLog;
   export let showTimestamps: boolean = false;
 
-  let isInited: boolean = false;
   let logTime: string = '';
 
   const pad = (num, size) => {
@@ -22,11 +21,7 @@
 
   $: {
     // (window as any)._vcOrigConsole.log('logRow update', log._id, ...log.data);
-    if (!isInited) {
-      isInited = true;
-    }
-
-    if (showTimestamps && logTime === '') {
+    if (showTimestamps) {
       const d = new Date(log.date);
       logTime = pad(d.getHours(), 2) + ':' + pad(d.getMinutes(), 2) + ':' + pad(d.getSeconds(), 2) + ':' + pad(d.getMilliseconds(), 3);
     }
@@ -77,7 +72,7 @@
     <div class="vc-log-content">
       {#each log.data as logData, i (i)}
         {#if isTree(logData.origData)}
-          <LogTree origData={logData.origData} />
+          <LogTree origData={logData.origData} keyPath={String(i)} toggle={log.toggle} />
         {:else}
           <LogValue origData={logData.origData} style={logData.style} />
         {/if}

--- a/src/log/logTree.svelte
+++ b/src/log/logTree.svelte
@@ -8,10 +8,11 @@
 
   export let origData: any;
   export let dataKey: string = undefined;
+  export let keyPath: string = ''
   export let keyType: '' | 'private' | 'symbol' = '';
+  export let toggle: Record<string, boolean> = {}
 
   const KEY_PAGE_SIZE = 50;
-  let isInited: boolean = false;
   let isToggle: boolean = false;
   let isTree: boolean = false;
   let isShowProto: boolean = false;
@@ -22,10 +23,9 @@
   let childNonEnumKeyOffset = KEY_PAGE_SIZE;
 
   $: {
-    if (!isInited) {
-      isTree = !(origData instanceof VConsoleUninvocatableObject) && (tool.isArray(origData) || tool.isObject(origData));
-      isInited = true;
-    }
+    isToggle = toggle[keyPath] || false
+
+    isTree = !(origData instanceof VConsoleUninvocatableObject) && (tool.isArray(origData) || tool.isObject(origData));
 
     if (isTree && isToggle) {
       // keys only need to be initialized once
@@ -57,6 +57,7 @@
   };
   const onTapTreeNode = () => {
     isToggle = !isToggle;
+    toggle[keyPath] = isToggle
   };
   const getValueByKey = (key: any) => {
     // invocate some object's property may cause error,
@@ -69,7 +70,7 @@
   };
 </script>
 
-<div class="vc-log-tree" class:vc-toggle={isToggle} class:vc-is-tree={isTree}>
+<div class="vc-log-tree" class:vc-toggle={isToggle} class:vc-is-tree={isTree} data-keypath={keyPath}>
 
   <div class="vc-log-tree-node" on:click={onTapTreeNode}>
     <LogValue origData={origData} dataKey={dataKey} keyType={keyType} />
@@ -79,7 +80,7 @@
     <div class="vc-log-tree-child">
       {#each childEnumKeys as key, i (key)}
         {#if i < childEnumKeyOffset}
-          <svelte:self origData={getValueByKey(key)} dataKey={key} />
+          <svelte:self origData={getValueByKey(key)} dataKey={key} keyPath={`${keyPath}.${key}`} toggle={toggle} />
         {/if}
       {/each}
       {#if childEnumKeyOffset < childEnumKeys.length}
@@ -87,12 +88,12 @@
       {/if}
 
       {#each childSymbolKeys as key (key)}
-        <svelte:self origData={getValueByKey(key)} dataKey={String(key)} keyType="symbol" />
+        <svelte:self origData={getValueByKey(key)} dataKey={String(key)} keyType="symbol" keyPath={`${keyPath}[${String(key)}]`} toggle={toggle} />
       {/each}
 
       {#each childNonEnumKeys as key, i (key)}
         {#if i < childNonEnumKeyOffset}
-          <svelte:self origData={getValueByKey(key)} dataKey={key} keyType="private" />
+          <svelte:self origData={getValueByKey(key)} dataKey={key} keyType="private" keyPath={`${keyPath}.${key}`} toggle={toggle} />
         {/if}
       {/each}
       {#if childNonEnumKeyOffset < childNonEnumKeys.length}
@@ -100,7 +101,7 @@
       {/if}
 
       {#if isShowProto}
-        <svelte:self origData={getValueByKey('__proto__')} dataKey="__proto__" keyType="private" />
+        <svelte:self origData={getValueByKey('__proto__')} dataKey="__proto__" keyType="private" keyPath={`${keyPath}.__proto__`} toggle={toggle} />
       {/if}
     </div>
   {/if}

--- a/src/log/logValue.svelte
+++ b/src/log/logValue.svelte
@@ -12,25 +12,19 @@
 
   let dataValue: string = '';
   let valueType: string = '';
-  let isInited: boolean = false;
   let isInTree: boolean = false;
 
   $: {
-    if (!isInited) {
-      // the value is NOT in a tree when key is undefined
-      isInTree = dataKey !== undefined;
+    // the value is NOT in a tree when key is undefined
+    isInTree = dataKey !== undefined;
 
-      const ret = getValueTextAndType(origData, isInTree);
-      valueType = ret.valueType;
-      dataValue = ret.text;
+    const ret = getValueTextAndType(origData, isInTree);
+    valueType = ret.valueType;
+    dataValue = ret.text;
 
-      if (!isInTree && valueType === 'string') {
-        // if it's a single string, then keep line breaks.
-        dataValue = dataValue.replace(/\\n/g, '\n').replace(/\\t/g, '    ');
-      }
-
-      // (window as any)._vcOrigConsole.log('logValue update', origData);
-      isInited = true;
+    if (!isInTree && valueType === 'string') {
+      // if it's a single string, then keep line breaks.
+      dataValue = dataValue.replace(/\\n/g, '\n').replace(/\\t/g, '    ');
     }
   }
 


### PR DESCRIPTION
1. 添加组件 RecycleScroller 实现虚拟滚动，在 log 面板上应用
1. 由于虚拟滚动的需要，修改了 log 面板布局样式：从绝对定位改为 flexbox
1. 由于虚拟滚动需要复用 logRow，将 logRow 以及其子组件逻辑改为可被复用
     1. 部分初始化逻辑从只执行一次改为，每次变更后执行
     2. logRow 的展开状态从局部变量改为存储到 log.model 中
1. log 面板添加 `top` 和 `bottom` 按钮用于快速滚动到顶部/底部
1. 由于虚拟滚动需要将 `vc-plugin-box` 高度固定为容器高度，而其他面板依赖其高度自然撑开进行默认滚动，为插件的 `renderTab` 调用添加了第二个可选参数，用于配置 tab。
    1. 添加了 `fixedHeight` 参数，用于指定将容器高度固定为 100%。