### PR TITLE
fix: such response type should just return themself not return a string

### DIFF
--- a/src/network/helper.ts
+++ b/src/network/helper.ts
@@ -60,7 +60,7 @@ export const genResonseByResponseType = (responseType: string, response: any) =>
     case 'formdata':
     default:
       if (typeof response !== 'undefined') {
-        ret = Object.prototype.toString.call(response);
+        ret = response;
       }
       break;
   }


### PR DESCRIPTION
## Why

When my application load `.wasm` file from xhr, method `getResonseByResponseType` make respone become a string. I think just return the origin response is make sense.