### PR TITLE
fix: Not working on IOS 17.2 Safari

### DIFF
--- a/src/component/icon/iconCopy.svelte
+++ b/src/component/icon/iconCopy.svelte
@@ -9,7 +9,7 @@
   const copyOptions = { target: document.documentElement };
   let showSuc = false;
 
-  const onTapIcon = (e) => {
+  const onTapIcon = async (e) => {
     let text = content;
     if (tool.isFunction(handler)) {
       text = handler(content) || '';
@@ -25,7 +25,16 @@
         text = content;
       }
     }
-    copy(text, copyOptions);
+    if (
+      navigator.clipboard &&
+      typeof navigator.clipboard.writeText === "function"
+    ) {
+      try {
+        await navigator.clipboard.writeText(text);
+      } catch (error) {}
+    } else {
+      copy(text, copyOptions);
+    }
     showSuc = true;
     setTimeout(() => {
       showSuc = false;


### PR DESCRIPTION
### vConsole 3.15.1
In IOS 17.2 Safari, clicking the copy icon does not work. To address this issue, the copy functionality can be implemented using the Clipboard API in modern browsers.