### PR TITLE
fix: escape quotemarks in Tree (and JSON copied)

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -206,7 +206,7 @@ const _safeJSONStringifyFlatValue = (value: any, maxLen = 0) => {
     if (maxLen > 0) {
       value = getStringWithinLength(value, maxLen);
     }
-    str += '"' + getVisibleText(value) + '"';
+    str += JSON.stringify(value);
   } else if (isSymbol(value)) {
     str += String(value).replace(/^Symbol\((.*)\)$/i, 'Symbol("$1")');
   } else if (isFunction(value)) {
@@ -265,7 +265,7 @@ const _safeJSONStringify = (obj, opt: ISafeJSONStringifyOption, _curDepth = 0) =
         if (isObject(key) || isArray(key) || isSymbol(key)) {
           opt.ret += Object.prototype.toString.call(key);
         } else if (isString(key) && opt.standardJSON) {
-          opt.ret += '"' + key + '"';
+          opt.ret += JSON.stringify(key);
         } else {
           opt.ret += key;
         }

--- a/src/log/logTool.ts
+++ b/src/log/logTool.ts
@@ -30,9 +30,10 @@ export const getValueTextAndType = (val: any, wrapString = true) => {
     text = getPreviewText(val);
   } else if (tool.isString(val)) {
     valueType = 'string';
-    text = tool.getVisibleText(val);
     if (wrapString) {
-      text = '"' + text + '"';
+      text = JSON.stringify(val);
+    } else {
+      text = tool.getVisibleText(val);
     }
   } else if (tool.isNumber(val)) {
     valueType = 'number';


### PR DESCRIPTION
BUG: when logging an object in which strings includes quotemark, for eg.

```javascript
console.log({ a: 'asdfdsa"as\ndfdsf"df' })
```
displays & copies an invalid json: `{"a": "asdfdsa"as\ndfdsf"df"}`

The pull request proposes an attempt to fix that issue. It is changed to `{"a": "asdfdsa\"as\ndfdsf\"df"}`

Meanwhile, behavior logging a string should not be change:

```javascript
console.log('asdfdsa"as\ndfdsf"df')
```

displays & copies

```
asdfdsa"as
dfdsf"df
```