### PR TITLE
fix: TypeError: Cannot convert undefined or null to object

### DIFF
--- a/src/network/network.svelte
+++ b/src/network/network.svelte
@@ -113,7 +113,7 @@
               <div class="vc-table-col vc-table-col-4 vc-table-col-value vc-max-height-line">{req.startTimeText}</div>
             </div>
           </div>
-          {#if (req.requestHeader !== null)}
+          {#if (req.requestHeader)}
           <div>
             <dl class="vc-table-row vc-left-border">
               <dt class="vc-table-col vc-table-col-title">


### PR DESCRIPTION
Issue to fix: https://github.com/Tencent/vConsole/issues/636

**Description:**
1. When page on load, the vconsole panel can be opened as well as the network panel.
2. After navigating around in my next.js app, the vconsole panel cannot be opened (after click) and there is error shows up: Uncaught (in promise) TypeError: Cannot convert undefined or null to object

**Steps to Reproduce (if applicable):**
1. Go forward and back in next.js app. （pages should perform requests）
2. click the vconsole floating panel.

**Expected Behavior:**
The Network panel can be opened and track the network activities.

**Actual Behavior:**
The vconsole panel and the Network panel cannot track the network activities.

**Additional Information:**
Error message:

```
vconsole.min.js:10 Uncaught (in promise) TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at po (vconsole.min.js:10:230313)
    at Array.xo (vconsole.min.js:10:239253)
    at y (vconsole.min.js:10:123857)
    at Array.ue (vconsole.min.js:10:189716)
    at y (vconsole.min.js:10:123857)
    at Cn (vconsole.min.js:10:176259)
    at xt (vconsole.min.js:10:129051)
    at new e (vconsole.min.js:10:177517)
    at se (vconsole.min.js:10:190371)
    at bt (vconsole.min.js:10:127194)
    at Object.p (vconsole.min.js:10:189407)
    at Object.p (vconsole.min.js:10:193586)
    at lt (vconsole.min.js:10:126559)
    at st (vconsole.min.js:10:126239)
```

**Proposed solution**
  Handle when `req.requestHeader` is undefined