### PR TITLE
fix: 解决storage无法修改key的问题

### DIFF
--- a/src/storage/storage.svelte
+++ b/src/storage/storage.svelte
@@ -41,10 +41,11 @@
     await model.removeItem(key);
   };
   const onTapSave = async (key: string) => {
+    model.setItem(editingKey, editingVal); // set value anyway
     if (editingKey !== key) {
       await model.removeItem(key); // dirty key
     }
-    model.setItem(editingKey, editingVal); // set value anyway
+
     resetEditState(); // reset editing status
   };
   const onTapEdit = async (key: string, value: string, i: number) => {
@@ -77,7 +78,7 @@
             <div class="vc-table-col">{k}</div>
             <div class="vc-table-col vc-table-col-2">{properDisplay(v)}</div>
           {/if}
-          
+
           <div class="vc-table-col vc-table-col-1 vc-table-action">
             {#if editingIdx === i}
               <Icon name="cancel" on:click={onTapCancelEdit} />


### PR DESCRIPTION
#690  优先执行model.removeItem(key)会导致状态被清理，从而导致model.setItem(editingKey, editingVal)无法被正常执行。故调换执行顺序。