### PR TITLE
Fix(Network):hijacking proxy resulted in WebAssembly.instantiateStreaming type error.(issue #590)

### DIFF
--- a/src/network/fetch.proxy.ts
+++ b/src/network/fetch.proxy.ts
@@ -223,6 +223,23 @@ export class FetchProxyHandler<T extends typeof fetch> implements ProxyHandler<T
       }
 
       this.onUpdateCallback(item);
+      
+      // Check if it's a WebAssembly-related request
+      // Determine if it's a WebAssembly file (.wasm) by checking the Content-Type or URL suffix.
+      const contentType = resp.headers.get('content-type');
+      const isWasmRequest = 
+        (contentType && contentType.includes('application/wasm')) || 
+        (item.url && item.url.toLowerCase().endsWith('.wasm')) ||
+        (item.url && item.url.toLowerCase().includes('/wasm'));
+      
+      // If it's a WebAssembly request, return the original Response object without proxying
+      if (isWasmRequest) {
+        // Log but do not affect the original Response
+        console.debug('[vConsole] WebAssembly request detected, skipping proxy for:', item.url);
+        return resp;
+      }
+      
+      // Other requests use proxy
       return new Proxy(resp, new ResponseProxyHandler(resp, item, this.onUpdateCallback));
     };
     return then;


### PR DESCRIPTION
When recognizing wasm, return the original object.

### reason

The below object caused a type error in `WebAssembly.instantiateStreaming`.

<img width="248" alt="image" src="https://github.com/user-attachments/assets/86decc81-8392-424a-9ee2-f30400647112" />