### PR TITLE
fix: add 'WS' to VConsoleRequestMethod type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vconsole",
-  "version": "3.15.1",
+  "version": "3.16.0-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vconsole",
-      "version": "3.15.1",
+      "version": "3.16.0-alpha",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.17.2",

--- a/src/network/requestItem.ts
+++ b/src/network/requestItem.ts
@@ -2,7 +2,7 @@
 import { getUniqueID } from '../lib/tool';
 import { genResonseByResponseType, genGetDataByUrl } from './helper';
 
-export type VConsoleRequestMethod = '' | 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH';
+export type VConsoleRequestMethod = '' | 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | 'WS';
 
 export interface VConsoleWebSocketMessage {
   type: 'send' | 'receive';


### PR DESCRIPTION
## Summary

Fix TypeScript compilation error in `websocket.proxy.ts` where the `method` property was set to `'WS'` but the `VConsoleRequestMethod` type definition didn't include it.

## Problem

Running `npm run build:typings` would fail with:

```
src/network/websocket.proxy.ts(14,5): error TS2322: Type '"WS"' is not assignable to type 'VConsoleRequestMethod'.
```

## Solution

Add `'WS'` to the `VConsoleRequestMethod` union type in `src/network/requestItem.ts`.

## Testing

- After this fix, `npm run build:typings` runs successfully
- `npm run build` completes without errors

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>