### PR TITLE
fix(Storage): prevent saving items with empty keys

### DIFF
--- a/src/storage/storage.svelte
+++ b/src/storage/storage.svelte
@@ -43,6 +43,10 @@
   const onTapSave = async (key: string) => {
     const savedKey = editingKey;
     const savedVal = editingVal;
+    // Validate that key is not empty before saving
+    if (!savedKey || savedKey.trim() === '') {
+      return;
+    }
     resetEditState();
     await model.setItem(savedKey, savedVal);
     if (savedKey !== key) {


### PR DESCRIPTION
## Summary
- Add validation to prevent saving storage items with empty keys
- Check if key is empty or contains only whitespace before saving
- Prevents creating invalid storage entries that are difficult to manage

## Bug Description
Previously, if a user cleared the key field in the storage editor and clicked save, vConsole would create a storage item with an empty key. These entries are:
- Difficult to select and modify in the UI
- Can cause unexpected behavior when filtering or searching
- Generally inconsistent with proper storage key conventions

## Fix
Added validation in `onTapSave` function that returns early if the key is empty or contains only whitespace, preventing the invalid save operation.

## Test Plan
- Open vConsole Storage tab
- Edit an existing storage item
- Clear the key field (or enter only spaces)
- Click the save/done button
- Verify that no empty-key item is created

## Related Issues
Addresses potential user-reported issues with storage editor behavior.