### PR TITLE
fix(Network): store empty string for query params without values

### DIFF
--- a/src/network/helper.ts
+++ b/src/network/helper.ts
@@ -85,7 +85,7 @@ export const genFormattedBody = (body?: BodyInit) => {
         ret = {};
         for (let q of arr) {
           const kv = q.split('=');
-          ret[ kv[0] ] = kv[1] === undefined ? 'undefined' : kv[1];
+          ret[ kv[0] ] = kv[1] === undefined ? '' : kv[1];
         }
       }
     }


### PR DESCRIPTION
## Summary
- Fix query parameter parsing to store empty string instead of 'undefined' for params without values
- Affects `genFormattedBody` in `helper.ts`

## Bug Description
When parsing URL query strings like `a=1&c`, parameters without values (like `c`) were being stored with the literal string `'undefined'` instead of an empty string.

Example:
- Input: `a=1&c`
- Before: `{ a: '1', c: 'undefined' }`
- After: `{ a: '1', c: '' }`

This is inconsistent with standard URL parameter handling where `c` and `c=` are typically treated the same way (both representing a parameter with an empty value).

## Fix
Changed the ternary operator in `genFormattedBody` to return an empty string (`''`) instead of the literal string `'undefined'` when `kv[1]` is undefined.

## Test Plan
- Make a request with query parameters that have no value (e.g., `?a=1&c`)
- Open vConsole Network tab
- View the request's Query String Parameters
- Verify that parameter `c` shows an empty string instead of 'undefined'

## Related Issues
Improves network request inspection accuracy.