### PR TITLE
fix(Core): use byte count for string length limit in getStringWithinLength

### DIFF
--- a/src/lib/tool.ts
+++ b/src/lib/tool.ts
@@ -387,8 +387,9 @@ export function getBytesText(bytes: number) {
  * @return 'some string...(3.1 MB)'
  */
 export function getStringWithinLength(str: string, maxLen: number) {
-  if (str.length > maxLen) {
-    str = str.substring(0, maxLen) + `...(${getBytesText(getStringBytes(str))})`;
+  const bytes = getStringBytes(str);
+  if (bytes > maxLen) {
+    str = str.substring(0, maxLen) + `...(${getBytesText(bytes)})`;
   }
   return str;
 }


### PR DESCRIPTION
## Summary
- Fix `getStringWithinLength` to use byte count instead of character count for limit check
- Ensures the function behaves consistently with its byte size display

## Bug Description
The `getStringWithinLength` function in `tool.ts` was using `str.length` (character count) instead of byte count when checking if the string exceeds the limit. This is inconsistent because:

1. The function appends byte size information (e.g., '...(3.1 MB)') when truncating
2. The helper function `getStringBytes` is already available
3. Multi-byte UTF-8 characters (like Chinese characters or emojis) can cause the actual byte size to far exceed the intended limit

Example of the issue:
- A string with 500 Chinese characters (each ~3 bytes in UTF-8) = ~1500 bytes
- If `maxLen` is 1000, the character check passes (500 < 1000)
- But the actual byte size (1500) exceeds the limit

## Fix
Changed to use `getStringBytes(str)` for the limit check:
```javascript
// Before
if (str.length > maxLen) { ... }

// After
const bytes = getStringBytes(str);
if (bytes > maxLen) { ... }
```

## Test Plan
- Test with strings containing multi-byte UTF-8 characters (Chinese, emojis, etc.)
- Verify that truncation happens based on byte count, not character count
- Confirm the displayed byte size is accurate

## Related Issues
Improves display consistency and prevents potential performance issues with large strings containing multi-byte characters.